### PR TITLE
Replaced conversation start with welcome node and removed threshold references

### DIFF
--- a/starter-kit/assistant/skill-CDC-COVID-FAQ.json
+++ b/starter-kit/assistant/skill-CDC-COVID-FAQ.json
@@ -4,19 +4,19 @@
       "intent": "PrepareFamily",
       "examples": [
         {
-          "text": "Prepare family"
-        },
-        {
           "text": "how do I prepare my household in case corona virus hits my community?"
         },
         {
-          "text": "what goes into a family emergency plan?"
+          "text": "Prepare family"
+        },
+        {
+          "text": "How can my family and I prepare for COVID-19?"
         },
         {
           "text": "should my household plan ahead?"
         },
         {
-          "text": "How can my family and I prepare for COVID-19?"
+          "text": "what goes into a family emergency plan?"
         }
       ],
       "description": "Family Preparation Guidance"
@@ -25,19 +25,19 @@
       "intent": "CDC_Response",
       "examples": [
         {
-          "text": "CDC response"
-        },
-        {
           "text": "Does CDC work to protect public health?"
         },
         {
-          "text": "How is CDC helping Americans prepare?"
+          "text": "CDC response"
+        },
+        {
+          "text": "What is the center for disease control doing to help?"
         },
         {
           "text": "What is CDC doing about COVID-19?"
         },
         {
-          "text": "What is the center for disease control doing to help?"
+          "text": "How is CDC helping Americans prepare?"
         }
       ],
       "description": "Info about the CDC"
@@ -46,19 +46,19 @@
       "intent": "RiskToPets",
       "examples": [
         {
-          "text": "Is there any danger to pets?"
-        },
-        {
           "text": "Can corona virus affect the pets?"
-        },
-        {
-          "text": "Are my pets in risk?"
         },
         {
           "text": "Risk to pets"
         },
         {
           "text": "Should I be concerned about pets or other animals and COVID-19?"
+        },
+        {
+          "text": "Are my pets in risk?"
+        },
+        {
+          "text": "Is there any danger to pets?"
         }
       ],
       "description": "Guidance on potential risk to Pets"
@@ -70,16 +70,13 @@
           "text": "person to person"
         },
         {
-          "text": "Can  Corona Virus (COVID-19) spread from person-to-person?"
+          "text": "Can I catch it from my friend?"
         },
         {
           "text": "Can someone who has had COVID-19 spread the illness to others?"
         },
         {
           "text": "How does  Corona Virus (COVID-19) spread?"
-        },
-        {
-          "text": "Can I catch it from my friend?"
         },
         {
           "text": "Why is  Corona Virus (COVID-19) spreading between people?"
@@ -89,6 +86,9 @@
         },
         {
           "text": "Who can I get it from?"
+        },
+        {
+          "text": "Can  Corona Virus (COVID-19) spread from person-to-person?"
         }
       ],
       "description": "Info on how Coronavirus spreads person to person"
@@ -100,19 +100,19 @@
           "text": "spread in quarantine"
         },
         {
-          "text": "what is the incubation period of this corona virus?"
-        },
-        {
-          "text": "Can someone who has been quarantined for COVID-19 spread the illness to others?"
-        },
-        {
           "text": "does putting infected people into quarantine help?"
+        },
+        {
+          "text": "what is a quarantine?"
         },
         {
           "text": "does quarantining people stop the spread of corona virus?"
         },
         {
-          "text": "what is a quarantine?"
+          "text": "Can someone who has been quarantined for COVID-19 spread the illness to others?"
+        },
+        {
+          "text": "what is the incubation period of this corona virus?"
         }
       ],
       "description": "does quarantining people stop the spread of corona virus?"
@@ -121,22 +121,22 @@
       "intent": "HealthDeptRecommendedActions",
       "examples": [
         {
-          "text": "can CDC help my local board of health"
+          "text": "What should healthcare professionals and health departments do?"
         },
         {
           "text": "how do I ship a specimen to the CDC lab?"
         },
         {
-          "text": "can CDC help my local health dept get protective gear?"
+          "text": "Health dept recommended actions"
         },
         {
           "text": "does CDC provide protocols for labs to test covid-19?"
         },
         {
-          "text": "Health dept recommended actions"
+          "text": "can CDC help my local health dept get protective gear?"
         },
         {
-          "text": "What should healthcare professionals and health departments do?"
+          "text": "can CDC help my local board of health"
         }
       ],
       "description": "Recommended actions by from the Health Dept"
@@ -145,19 +145,19 @@
       "intent": "Testing",
       "examples": [
         {
-          "text": "Testing"
-        },
-        {
           "text": "should I head to the doctor if I show symptoms?"
         },
         {
-          "text": "can my doctor test me if I start feeling sick?"
+          "text": "Should I be tested for COVID-19?"
         },
         {
           "text": "who should get tested?"
         },
         {
-          "text": "Should I be tested for COVID-19?"
+          "text": "Testing"
+        },
+        {
+          "text": "can my doctor test me if I start feeling sick?"
         }
       ],
       "description": "When, where, how of getting yourself tested"
@@ -166,19 +166,19 @@
       "intent": "NegativeTestResults",
       "examples": [
         {
-          "text": "Can you have corona virus and still test negative?"
-        },
-        {
-          "text": "if you test negative can you still get COVID-19 later?"
-        },
-        {
           "text": "Can a person test negative and later test positive for COVID-19?"
         },
         {
           "text": "Does a negative test mean a person does not have COVID-19?"
         },
         {
+          "text": "if you test negative can you still get COVID-19 later?"
+        },
+        {
           "text": "Negative test results"
+        },
+        {
+          "text": "Can you have corona virus and still test negative?"
         }
       ],
       "description": "Considerations for receiving negative test results"
@@ -187,19 +187,19 @@
       "intent": "ReduceFamilyRisk",
       "examples": [
         {
-          "text": "What steps can my family take to reduce our risk of getting COVID-19?"
-        },
-        {
           "text": "lower my family's risk of getting sick"
-        },
-        {
-          "text": "Reduce family risk"
         },
         {
           "text": "What should I have my family do to keep from getting sick?"
         },
         {
           "text": "what are the top tips to keep my family from catching it?"
+        },
+        {
+          "text": "What steps can my family take to reduce our risk of getting COVID-19?"
+        },
+        {
+          "text": "Reduce family risk"
         }
       ],
       "description": "Guidance on reducing risk to your family"
@@ -208,34 +208,7 @@
       "intent": "HigherRiskPopulations",
       "examples": [
         {
-          "text": "Can Millennials get it? "
-        },
-        {
           "text": "Are older adults more likely to contract the disease?"
-        },
-        {
-          "text": "I have a chronic illness."
-        },
-        {
-          "text": "I have underlying health issues."
-        },
-        {
-          "text": "Why are people with pre-existing conditions more at risk?"
-        },
-        {
-          "text": "Who is dying? "
-        },
-        {
-          "text": "Who is at higher risk for serious illness from COVID-19?"
-        },
-        {
-          "text": "What does immunocompromised mean? "
-        },
-        {
-          "text": "Why do Boomers get sick? "
-        },
-        {
-          "text": "Are all the old people going to die? "
         },
         {
           "text": "I am over the age of 60."
@@ -259,7 +232,34 @@
           "text": "Do seniors need to take extra precautions?"
         },
         {
+          "text": "Can Millennials get it? "
+        },
+        {
           "text": "Can Gen-X get sick? "
+        },
+        {
+          "text": "Are all the old people going to die? "
+        },
+        {
+          "text": "Why do Boomers get sick? "
+        },
+        {
+          "text": "What does immunocompromised mean? "
+        },
+        {
+          "text": "Who is at higher risk for serious illness from COVID-19?"
+        },
+        {
+          "text": "Who is dying? "
+        },
+        {
+          "text": "Why are people with pre-existing conditions more at risk?"
+        },
+        {
+          "text": "I have underlying health issues."
+        },
+        {
+          "text": "I have a chronic illness."
         }
       ],
       "description": "Identify which populations are at higher risk"
@@ -271,10 +271,10 @@
           "text": "spread via food"
         },
         {
-          "text": "does the virus stick to packaged food?"
+          "text": "does it spread on food packaging?"
         },
         {
-          "text": "does it spread on food packaging?"
+          "text": "does the virus stick to packaged food?"
         },
         {
           "text": "Can the virus that causes COVID-19 be spread through food, including refrigerated or frozen food?"
@@ -289,9 +289,6 @@
       "intent": "DataSource",
       "examples": [
         {
-          "text": "Where did you learn this?"
-        },
-        {
           "text": "Is this true?"
         },
         {
@@ -305,6 +302,9 @@
         },
         {
           "text": "Where do you get your information?"
+        },
+        {
+          "text": "Where did you learn this?"
         }
       ],
       "description": "Information on where this bot sourced it's data"
@@ -312,9 +312,6 @@
     {
       "intent": "DisinfectingSurfaces",
       "examples": [
-        {
-          "text": "what products are best at disinfecting?"
-        },
         {
           "text": "Disinfecting surfaces"
         },
@@ -329,6 +326,9 @@
         },
         {
           "text": "What cleaning products should I use to protect against COVID-19?"
+        },
+        {
+          "text": "what products are best at disinfecting?"
         },
         {
           "text": "Where do i need to disinfect?"
@@ -361,9 +361,6 @@
       "intent": "ChildrenSocializing",
       "examples": [
         {
-          "text": "do kids need to limit in person contact?"
-        },
-        {
           "text": "Is social distancing important for kids too?"
         },
         {
@@ -377,6 +374,9 @@
         },
         {
           "text": "Children socializing"
+        },
+        {
+          "text": "do kids need to limit in person contact?"
         }
       ],
       "description": "Child Socialization guidance"
@@ -385,22 +385,22 @@
       "intent": "Symptoms",
       "examples": [
         {
-          "text": "Symptoms"
+          "text": "is fever a sign of this infection?"
         },
         {
           "text": "What are the symptoms and complications that COVID-19 can cause?"
         },
         {
-          "text": "is fever a sign of this infection?"
+          "text": "Symptoms"
         },
         {
-          "text": "does covid-19 cause fever?"
+          "text": "what symptoms should I watch for?"
         },
         {
           "text": "does covid-19 cause coughing?"
         },
         {
-          "text": "what symptoms should I watch for?"
+          "text": "does covid-19 cause fever?"
         }
       ],
       "description": "General info on symptoms of covid-19 disease"
@@ -409,6 +409,12 @@
       "intent": "HowDoesItSpread",
       "examples": [
         {
+          "text": "How does it spread"
+        },
+        {
+          "text": "how did the virus spread from China?"
+        },
+        {
           "text": "does the corona virus spread easily?"
         },
         {
@@ -416,12 +422,6 @@
         },
         {
           "text": "How does the virus spread?"
-        },
-        {
-          "text": "How does it spread"
-        },
-        {
-          "text": "how did the virus spread from China?"
         }
       ],
       "description": "Info on how COVID Spreads"
@@ -430,7 +430,16 @@
       "intent": "Wearingfacemasks",
       "examples": [
         {
-          "text": "What do face masks do? "
+          "text": "Should I use a face mask when in public?"
+        },
+        {
+          "text": "Wearing face masks"
+        },
+        {
+          "text": "Should my child wear a face mask?"
+        },
+        {
+          "text": "Should I wear a face mask?"
         },
         {
           "text": "Do face masks do anything?"
@@ -439,22 +448,13 @@
           "text": "Does CDC recommend the use of facemask to prevent COVID-19?"
         },
         {
-          "text": "Should I use a face mask when in public?"
+          "text": "Do I need to wear a face mask?"
         },
         {
-          "text": "Should I wear a face mask?"
-        },
-        {
-          "text": "Should my child wear a face mask?"
+          "text": "What do face masks do? "
         },
         {
           "text": "Someone in my household is sick should we wear masks at home?"
-        },
-        {
-          "text": "Wearing face masks"
-        },
-        {
-          "text": "Do I need to wear a face mask?"
         }
       ],
       "description": "General facemask questions"
@@ -463,46 +463,46 @@
       "intent": "USinfectionlevel",
       "examples": [
         {
-          "text": "US infection level"
+          "text": "How many people in the U.S. have  Corona Virus (COVID-19)?"
         },
         {
           "text": "Are there any confirmed case in the US?"
         },
         {
-          "text": "How many people recovered in America?"
-        },
-        {
-          "text": "How many cases are there in the United States?"
-        },
-        {
-          "text": "How many cases in the U.S.?"
-        },
-        {
-          "text": "How many deaths in the US?"
-        },
-        {
-          "text": "How many recovered in the United States?"
-        },
-        {
-          "text": "How many people have died in the U.S.? "
-        },
-        {
-          "text": "Has anyone in the United States gotten infected?"
-        },
-        {
-          "text": "How many people in the U.S. have  Corona Virus (COVID-19)?"
-        },
-        {
-          "text": "What is the total number of deaths in the US?"
-        },
-        {
-          "text": "What is the status of US cases?"
+          "text": "How many cases are there in America?"
         },
         {
           "text": "How many infected people are there in America? "
         },
         {
-          "text": "How many cases are there in America?"
+          "text": "What is the status of US cases?"
+        },
+        {
+          "text": "How many people have died in the U.S.? "
+        },
+        {
+          "text": "How many deaths in the US?"
+        },
+        {
+          "text": "How many cases in the U.S.?"
+        },
+        {
+          "text": "How many cases are there in the United States?"
+        },
+        {
+          "text": "How many people recovered in America?"
+        },
+        {
+          "text": "What is the total number of deaths in the US?"
+        },
+        {
+          "text": "How many recovered in the United States?"
+        },
+        {
+          "text": "US infection level"
+        },
+        {
+          "text": "Has anyone in the United States gotten infected?"
         }
       ],
       "description": "National stats"
@@ -741,13 +741,13 @@
       "intent": "schoolclosing",
       "examples": [
         {
-          "text": "why are schools closing?"
+          "text": "school closing"
         },
         {
           "text": "who gets to decide if the school will close?"
         },
         {
-          "text": "school closing"
+          "text": "why are schools closing?"
         },
         {
           "text": "how do I know if my school is closing?"
@@ -762,25 +762,28 @@
       "intent": "How_many_cases",
       "examples": [
         {
-          "text": "What is the stats on Corona Virus?"
+          "text": "how many cases in the world"
         },
         {
           "text": "How many cases of corona virus has been detected?"
         },
         {
-          "text": "How many cases so far?"
+          "text": "What is the stats on Corona Virus?"
         },
         {
-          "text": "How many cases of Covid 19 has been detected?"
-        },
-        {
-          "text": "How many cases of covid 19 have been detected?"
+          "text": "What are the stats on COVID-19?"
         },
         {
           "text": "Total Cases so Far"
         },
         {
-          "text": "What are the stats on COVID-19?"
+          "text": "How many cases so far?"
+        },
+        {
+          "text": "How many cases of covid 19 have been detected?"
+        },
+        {
+          "text": "How many cases of Covid 19 has been detected?"
         }
       ],
       "description": "Stats on number of infections"
@@ -789,19 +792,19 @@
       "intent": "ChildrenAndFaceMasks",
       "examples": [
         {
-          "text": "does my daughter need to wear a facemask?"
-        },
-        {
-          "text": "are facemasks recommended for children"
+          "text": "Children and facemasks"
         },
         {
           "text": "can my child play outside without a mask?"
         },
         {
-          "text": "Children and facemasks"
+          "text": "does my daughter need to wear a facemask?"
         },
         {
           "text": "Should children wear masks?"
+        },
+        {
+          "text": "are facemasks recommended for children"
         }
       ],
       "description": "Guidance regarding Children wearing Facemasks"
@@ -810,25 +813,25 @@
       "intent": "CommunitySpread",
       "examples": [
         {
-          "text": "Community Spread"
-        },
-        {
-          "text": "What does that term community spread mean?"
-        },
-        {
-          "text": "How does community spread happen? "
-        },
-        {
-          "text": "Does  Corona Virus (COVID-19) spread to an entire community?"
-        },
-        {
           "text": "Why is community spread of this virus important?"
         },
         {
           "text": "What is community spread?"
         },
         {
+          "text": "What does that term community spread mean?"
+        },
+        {
           "text": "Can community spread happen? "
+        },
+        {
+          "text": "Community Spread"
+        },
+        {
+          "text": "Does  Corona Virus (COVID-19) spread to an entire community?"
+        },
+        {
+          "text": "How does community spread happen? "
         }
       ],
       "description": "Defining Community Spread"
@@ -858,6 +861,9 @@
           "text": "covid 19"
         },
         {
+          "text": "Carona Virus"
+        },
+        {
           "text": "Why did  Corona Virus (COVID-19) spread?"
         },
         {
@@ -868,9 +874,6 @@
         },
         {
           "text": "When did  Corona Virus (COVID-19) start?"
-        },
-        {
-          "text": "Carona Virus"
         },
         {
           "text": "what is carona virus?"
@@ -903,6 +906,12 @@
       "intent": "Symptomsinchildren",
       "examples": [
         {
+          "text": "do kids get different symptoms?"
+        },
+        {
+          "text": "what are the symptoms in children?"
+        },
+        {
           "text": "Symptoms in children"
         },
         {
@@ -910,12 +919,6 @@
         },
         {
           "text": "do children react differently to the virus than adults do?"
-        },
-        {
-          "text": "do kids get different symptoms?"
-        },
-        {
-          "text": "what are the symptoms in children?"
         }
       ],
       "description": "Signs and symptoms in children and differences from adults"
@@ -924,19 +927,19 @@
       "intent": "warmerweather",
       "examples": [
         {
+          "text": "Will warm weather stop the outbreak of COVID-19?"
+        },
+        {
           "text": "i heard the spread will slow down in warmer months"
+        },
+        {
+          "text": "does it get less contagious in the summer?"
         },
         {
           "text": "warmer weather"
         },
         {
           "text": "will the virus go away during warmer months?"
-        },
-        {
-          "text": "Will warm weather stop the outbreak of COVID-19?"
-        },
-        {
-          "text": "does it get less contagious in the summer?"
         }
       ],
       "description": "Does warmer weather or summer weather have an effect on the virus or the pandemic"
@@ -972,7 +975,7 @@
       "intent": "InfectedFamilyMember",
       "examples": [
         {
-          "text": "what do i do when someone in my home gets it?"
+          "text": "my roommate has corona virus what should I do?"
         },
         {
           "text": "Infected family member"
@@ -984,7 +987,7 @@
           "text": "What should I do if someone in my house gets sick with COVID-19?"
         },
         {
-          "text": "my roommate has corona virus what should I do?"
+          "text": "what do i do when someone in my home gets it?"
         }
       ],
       "description": "Guidance if a Family Member is infected"
@@ -993,6 +996,12 @@
       "intent": "MealsForStudents",
       "examples": [
         {
+          "text": "are schools continuing to serve school lunch plans even if classes are closed?"
+        },
+        {
+          "text": "will school students be able to get their free meals?"
+        },
+        {
           "text": "While school’s out, will kids have access to meals?"
         },
         {
@@ -1000,12 +1009,6 @@
         },
         {
           "text": "how are students on school lunch plans getting their meals?"
-        },
-        {
-          "text": "are schools continuing to serve school lunch plans even if classes are closed?"
-        },
-        {
-          "text": "will school students be able to get their free meals?"
         }
       ],
       "description": "Info regarding school and student meals"
@@ -1014,49 +1017,55 @@
       "intent": "greeting",
       "examples": [
         {
-          "text": "Good morning"
-        },
-        {
           "text": "howdy"
         },
         {
-          "text": "hey"
+          "text": "hi there"
         },
         {
-          "text": "hiya"
-        },
-        {
-          "text": "hi"
-        },
-        {
-          "text": "hey there"
-        },
-        {
-          "text": "feeling a bit low"
-        },
-        {
-          "text": "hello watson"
-        },
-        {
-          "text": "good evening"
-        },
-        {
-          "text": "Good afternoon"
-        },
-        {
-          "text": "ciao"
-        },
-        {
-          "text": "buenos dias"
-        },
-        {
-          "text": "bonjour"
+          "text": "heya"
         },
         {
           "text": "aloha"
         },
         {
-          "text": "heya"
+          "text": "bonjour"
+        },
+        {
+          "text": "buenos dias"
+        },
+        {
+          "text": "ciao"
+        },
+        {
+          "text": "hello watson"
+        },
+        {
+          "text": "hey there"
+        },
+        {
+          "text": "hi"
+        },
+        {
+          "text": "hiya"
+        },
+        {
+          "text": "hola"
+        },
+        {
+          "text": "feeling a bit low"
+        },
+        {
+          "text": "Good morning"
+        },
+        {
+          "text": "Good afternoon"
+        },
+        {
+          "text": "good evening"
+        },
+        {
+          "text": "hey"
         },
         {
           "text": "hello"
@@ -1072,12 +1081,6 @@
         },
         {
           "text": "namaste"
-        },
-        {
-          "text": "hi there"
-        },
-        {
-          "text": "hola"
         }
       ]
     },
@@ -1085,28 +1088,28 @@
       "intent": "HandwashingTips",
       "examples": [
         {
-          "text": "is hand sanitizer effective against covid-19?"
-        },
-        {
-          "text": "Should I use soap and water or a hand sanitizer to protect against COVID-19?"
-        },
-        {
           "text": "should i keep washing my hands"
-        },
-        {
-          "text": "will washing my hands help protect me?"
-        },
-        {
-          "text": "handwashing products"
         },
         {
           "text": "Handwashing tips"
         },
         {
-          "text": "how do i wash my hands correctly?"
+          "text": "is hand sanitizer effective against covid-19?"
+        },
+        {
+          "text": "handwashing products"
+        },
+        {
+          "text": "will washing my hands help protect me?"
         },
         {
           "text": "will frequent handwashing help?"
+        },
+        {
+          "text": "how do i wash my hands correctly?"
+        },
+        {
+          "text": "Should I use soap and water or a hand sanitizer to protect against COVID-19?"
         }
       ],
       "description": "Hand Washing Guidance"
@@ -1115,12 +1118,6 @@
       "intent": "ProductsFromChina",
       "examples": [
         {
-          "text": "Products from China"
-        },
-        {
-          "text": "is it safe to buy Chinese products?"
-        },
-        {
           "text": "Am I at risk for COVID-19 from a package or products shipping from China?"
         },
         {
@@ -1128,6 +1125,12 @@
         },
         {
           "text": "should i stop buying products from China?"
+        },
+        {
+          "text": "Products from China"
+        },
+        {
+          "text": "is it safe to buy Chinese products?"
         }
       ],
       "description": "Guidance regarding packages from China"
@@ -1136,16 +1139,16 @@
       "intent": "Schoolfromhome",
       "examples": [
         {
-          "text": "School from home"
-        },
-        {
           "text": "how do I keep my child engaged in schoolwork?"
         },
         {
-          "text": "While school’s out, how can I help my child continue learning?"
+          "text": "Tips for my child's schedule when school is canceled."
         },
         {
-          "text": "Tips for my child's schedule when school is canceled."
+          "text": "School from home"
+        },
+        {
+          "text": "While school’s out, how can I help my child continue learning?"
         },
         {
           "text": "I need tips for at home learning"
@@ -1157,6 +1160,9 @@
       "intent": "AttendingFuneral",
       "examples": [
         {
+          "text": "Should I avoid funerals?"
+        },
+        {
           "text": "Are funerals safe? "
         },
         {
@@ -1164,9 +1170,6 @@
         },
         {
           "text": "Can I go to a funeral? "
-        },
-        {
-          "text": "Should I avoid funerals?"
         },
         {
           "text": "Am I at risk if I go to a funeral or visitation service for someone who died of COVID-19?"
@@ -1178,19 +1181,19 @@
       "intent": "ReportingToWork",
       "examples": [
         {
-          "text": "will my office be closed?"
+          "text": "what are my work from home options?"
         },
         {
           "text": "I'm supposed to work but my child's school is canceled"
+        },
+        {
+          "text": "will my office be closed?"
         },
         {
           "text": "Reporting to work"
         },
         {
           "text": "Should I go to work if there is an outbreak in my community?"
-        },
-        {
-          "text": "what are my work from home options?"
         }
       ],
       "description": "Guidance on going in to work"
@@ -1199,16 +1202,16 @@
       "intent": "ProtectingChildren",
       "examples": [
         {
-          "text": "How can I protect my child from COVID-19 infection?"
+          "text": "should I disinfect my kid's toys?"
         },
         {
-          "text": "is handwashing important for children?"
+          "text": "How can I protect my child from COVID-19 infection?"
         },
         {
           "text": "Protecting children"
         },
         {
-          "text": "should I disinfect my kid's toys?"
+          "text": "is handwashing important for children?"
         },
         {
           "text": "what will protect my kids from getting the infection?"
@@ -1220,22 +1223,22 @@
       "intent": "Whythename",
       "examples": [
         {
-          "text": "is corona virus the same as covid-19?"
+          "text": "Why is the disease being called coronavirus disease 2019, COVID-19?"
         },
         {
           "text": "why is covid-19 the name for this disease?"
         },
         {
-          "text": "Why is the disease being called coronavirus disease 2019, COVID-19?"
+          "text": "Why the name"
         },
         {
           "text": "why was covid-19 used to name this disease?"
         },
         {
-          "text": "Why the name"
+          "text": "is covid an abbreviation?"
         },
         {
-          "text": "is covid an abbreviation?"
+          "text": "is corona virus the same as covid-19?"
         }
       ],
       "description": "Answer how the name for this virus and disease arose."
@@ -1247,19 +1250,19 @@
           "text": "do children catch covid-19?"
         },
         {
-          "text": "Risk to children"
-        },
-        {
-          "text": "Are children at higher risk of getting sick?"
-        },
-        {
           "text": "What is the risk of my child becoming sick with COVID-19?"
+        },
+        {
+          "text": "Can corona virus infect an infant?"
         },
         {
           "text": "Are kids at increased risk of infection?"
         },
         {
-          "text": "Can corona virus infect an infant?"
+          "text": "Risk to children"
+        },
+        {
+          "text": "Are children at higher risk of getting sick?"
         }
       ],
       "description": "Guidance on potential risk to Children"
@@ -1271,13 +1274,13 @@
           "text": "NEWS"
         },
         {
+          "text": "Whats happening?"
+        },
+        {
           "text": "What is in the NEWS?"
         },
         {
           "text": "whats happening"
-        },
-        {
-          "text": "Whats happening?"
         }
       ],
       "description": ""
@@ -1289,10 +1292,10 @@
           "text": "Where did it start"
         },
         {
-          "text": "which location did corona virus start from?"
+          "text": "What is the source of the virus?"
         },
         {
-          "text": "What is the source of the virus?"
+          "text": "which location did corona virus start from?"
         },
         {
           "text": "Where did corona virus originate from?"
@@ -1467,7 +1470,7 @@
   },
   "webhooks": [
     {
-      "url": "https://us-south.functions.cloud.ibm.com/api/v1/web/Developer%20Advocacy_Cloud%20Developer%20Advocacy/covid-starter-kit/discovery-covid-async.json",
+      "url": "https://us-south.functions.cloud.ibm.com/api/v1/web/upkar.ibm.watson.3%40gmail.com_dev/default/COVID-ACTION.json",
       "name": "main_webhook",
       "headers": []
     }
@@ -1807,7 +1810,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#ProtectingChildren && intents[0].confidence > $low_confidence)",
+      "conditions": "#ProtectingChildren",
       "dialog_node": "node_11765",
       "previous_sibling": "node_11764"
     },
@@ -1827,7 +1830,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#HigherRiskPopulations && intents[0].confidence > $low_confidence)",
+      "conditions": "#HigherRiskPopulations",
       "dialog_node": "node_11761",
       "previous_sibling": "node_11760"
     },
@@ -1840,7 +1843,7 @@
           "type": "webhook",
           "parameters": {
             "type": "api",
-            "country": "US"
+            "country": "United States of America"
           },
           "result_variable": "us_result"
         }
@@ -1850,7 +1853,7 @@
           "mcr": true
         }
       },
-      "conditions": "(#USinfectionlevel && intents[0].confidence > $low_confidence)",
+      "conditions": "#USinfectionlevel",
       "dialog_node": "node_11760",
       "previous_sibling": "node_11759"
     },
@@ -1870,7 +1873,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Schoolfromhome && intents[0].confidence > $low_confidence)",
+      "conditions": "#Schoolfromhome",
       "dialog_node": "node_11786",
       "previous_sibling": "node_11785"
     },
@@ -1890,7 +1893,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#WhatisCovid && intents[0].confidence > $low_confidence)",
+      "conditions": "#WhatisCovid",
       "dialog_node": "node_11751",
       "previous_sibling": "node_2_1584976214871"
     },
@@ -1910,7 +1913,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#RiskToChildren && intents[0].confidence > $low_confidence)",
+      "conditions": "#RiskToChildren",
       "dialog_node": "node_11764",
       "previous_sibling": "node_11763"
     },
@@ -1930,7 +1933,7 @@
           }
         ]
       },
-      "conditions": "(#DataSource && intents[0].confidence > $low_confidence)",
+      "conditions": "#DataSource",
       "dialog_node": "node_8_1585238958758",
       "previous_sibling": "node_11787"
     },
@@ -1950,7 +1953,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#PrepareFamily && intents[0].confidence > $low_confidence)",
+      "conditions": "#PrepareFamily",
       "dialog_node": "node_11768",
       "previous_sibling": "node_11767"
     },
@@ -1970,7 +1973,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Symptomsinchildren && intents[0].confidence > $low_confidence)",
+      "conditions": "#Symptomsinchildren",
       "dialog_node": "node_11766",
       "previous_sibling": "node_11765"
     },
@@ -1990,7 +1993,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#ChildrenSocializing && intents[0].confidence > $low_confidence)",
+      "conditions": "#ChildrenSocializing",
       "dialog_node": "node_11785",
       "previous_sibling": "node_11784"
     },
@@ -2054,7 +2057,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#schoolclosing && intents[0].confidence > $low_confidence)",
+      "conditions": "#schoolclosing",
       "dialog_node": "node_11774",
       "previous_sibling": "node_11773"
     },
@@ -2074,7 +2077,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#CommunitySpread && intents[0].confidence > $low_confidence)",
+      "conditions": "#CommunitySpread",
       "dialog_node": "node_11759",
       "previous_sibling": "node_11758"
     },
@@ -2094,7 +2097,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#InfectedFamilyMember && intents[0].confidence > $low_confidence)",
+      "conditions": "#InfectedFamilyMember",
       "dialog_node": "node_11770",
       "previous_sibling": "node_11769"
     },
@@ -2114,7 +2117,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#AnimalContact && intents[0].confidence > $low_confidence)",
+      "conditions": "#AnimalContact",
       "dialog_node": "node_11784",
       "previous_sibling": "node_11783"
     },
@@ -2134,7 +2137,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#HealthDeptRecommendedActions && intents[0].confidence > $low_confidence)",
+      "conditions": "#HealthDeptRecommendedActions",
       "dialog_node": "node_11780",
       "previous_sibling": "node_11779"
     },
@@ -2154,7 +2157,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Stigmatizedgroups && intents[0].confidence > $low_confidence)",
+      "conditions": "#Stigmatizedgroups",
       "dialog_node": "node_11779",
       "previous_sibling": "node_11778"
     },
@@ -2174,7 +2177,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#HowDoesItSpread && intents[0].confidence > $low_confidence)",
+      "conditions": "#HowDoesItSpread",
       "dialog_node": "node_11753",
       "previous_sibling": "node_11752"
     },
@@ -2194,7 +2197,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Wearingfacemasks && intents[0].confidence > $low_confidence)",
+      "conditions": "#Wearingfacemasks",
       "dialog_node": "node_11762",
       "previous_sibling": "node_11761"
     },
@@ -2214,7 +2217,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#PreparingChildren && intents[0].confidence > $low_confidence)",
+      "conditions": "#PreparingChildren",
       "dialog_node": "node_11773",
       "previous_sibling": "node_11772"
     },
@@ -2234,7 +2237,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#spreadviafood && intents[0].confidence > $low_confidence)",
+      "conditions": "#spreadviafood",
       "dialog_node": "node_11757",
       "previous_sibling": "node_11756"
     },
@@ -2254,7 +2257,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#MealsForStudents && intents[0].confidence > $low_confidence)",
+      "conditions": "#MealsForStudents",
       "dialog_node": "node_11787",
       "previous_sibling": "node_11786"
     },
@@ -2274,7 +2277,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Wherediditstart && intents[0].confidence > $low_confidence)",
+      "conditions": "#Wherediditstart",
       "dialog_node": "node_11754",
       "previous_sibling": "node_11753"
     },
@@ -2294,7 +2297,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#RiskToPets && intents[0].confidence > $low_confidence)",
+      "conditions": "#RiskToPets",
       "dialog_node": "node_11783",
       "previous_sibling": "node_11782"
     },
@@ -2316,7 +2319,7 @@
         ]
       },
       "context": {},
-      "conditions": "#goodbyes && intents[0].confidence > 0.95",
+      "conditions": "#goodbyes",
       "dialog_node": "node_11791",
       "previous_sibling": "node_9_1586187460728"
     },
@@ -2336,7 +2339,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#ReportingToWork && intents[0].confidence > $low_confidence)",
+      "conditions": "#ReportingToWork",
       "dialog_node": "node_11775",
       "previous_sibling": "node_11774"
     },
@@ -2362,7 +2365,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#ProductsFromChina && intents[0].confidence > $low_confidence)",
+      "conditions": "#ProductsFromChina",
       "dialog_node": "node_11763",
       "previous_sibling": "node_11762"
     },
@@ -2402,7 +2405,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#HandwashingTips && intents[0].confidence > $low_confidence)",
+      "conditions": "#HandwashingTips",
       "dialog_node": "node_11771",
       "previous_sibling": "node_11770"
     },
@@ -2422,7 +2425,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#CDC_Response && intents[0].confidence > $low_confidence)",
+      "conditions": "#CDC_Response",
       "dialog_node": "node_11782",
       "previous_sibling": "node_11781"
     },
@@ -2442,7 +2445,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#warmerweather && intents[0].confidence > $low_confidence)",
+      "conditions": "#warmerweather",
       "dialog_node": "node_11758",
       "previous_sibling": "node_11757"
     },
@@ -2462,7 +2465,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Symptoms && intents[0].confidence > $low_confidence)",
+      "conditions": "#Symptoms",
       "dialog_node": "node_11776",
       "previous_sibling": "node_11775"
     },
@@ -2482,7 +2485,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#spreadinquarantine && intents[0].confidence > $low_confidence)",
+      "conditions": "#spreadinquarantine",
       "dialog_node": "node_11756",
       "previous_sibling": "node_11755"
     },
@@ -2502,7 +2505,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Testing && intents[0].confidence > $low_confidence)",
+      "conditions": "#Testing",
       "dialog_node": "node_11777",
       "previous_sibling": "node_11776"
     },
@@ -2522,7 +2525,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#DisinfectingSurfaces && intents[0].confidence > $low_confidence)",
+      "conditions": "#DisinfectingSurfaces",
       "dialog_node": "node_11772",
       "previous_sibling": "node_11771"
     },
@@ -2542,7 +2545,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#ChildrenAndFaceMasks && intents[0].confidence > $low_confidence)",
+      "conditions": "#ChildrenAndFaceMasks",
       "dialog_node": "node_11767",
       "previous_sibling": "node_11766"
     },
@@ -2562,7 +2565,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#PersonToPerson && intents[0].confidence > $low_confidence)",
+      "conditions": "#PersonToPerson",
       "dialog_node": "node_11755",
       "previous_sibling": "node_11754"
     },
@@ -2582,7 +2585,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#ReduceFamilyRisk && intents[0].confidence > $low_confidence)",
+      "conditions": "#ReduceFamilyRisk",
       "dialog_node": "node_11769",
       "previous_sibling": "node_11768"
     },
@@ -2602,7 +2605,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#AttendingFuneral && intents[0].confidence > $low_confidence)",
+      "conditions": "#AttendingFuneral",
       "dialog_node": "node_11781",
       "previous_sibling": "node_11780"
     },
@@ -2622,7 +2625,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#NegativeTestResults && intents[0].confidence > $low_confidence)",
+      "conditions": "#NegativeTestResults",
       "dialog_node": "node_11778",
       "previous_sibling": "node_11777"
     },
@@ -2642,7 +2645,7 @@
         ]
       },
       "context": {},
-      "conditions": "(#Whythename && intents[0].confidence > $low_confidence)",
+      "conditions": "#Whythename",
       "dialog_node": "node_11752",
       "previous_sibling": "node_11751"
     },

--- a/starter-kit/assistant/skill-CDC-COVID-FAQ.json
+++ b/starter-kit/assistant/skill-CDC-COVID-FAQ.json
@@ -1,80 +1,299 @@
 {
   "intents": [
     {
-      "intent": "Whythename",
+      "intent": "PrepareFamily",
       "examples": [
         {
-          "text": "why is covid-19 the name for this disease?"
+          "text": "Prepare family"
         },
         {
-          "text": "Why is the disease being called coronavirus disease 2019, COVID-19?"
+          "text": "how do I prepare my household in case corona virus hits my community?"
         },
         {
-          "text": "is corona virus the same as covid-19?"
+          "text": "what goes into a family emergency plan?"
         },
         {
-          "text": "why was covid-19 used to name this disease?"
+          "text": "should my household plan ahead?"
         },
         {
-          "text": "Why the name"
-        },
-        {
-          "text": "is covid an abbreviation?"
+          "text": "How can my family and I prepare for COVID-19?"
         }
       ],
-      "description": "Answer how the name for this virus and disease arose."
+      "description": "Family Preparation Guidance"
     },
     {
-      "intent": "HandwashingTips",
+      "intent": "CDC_Response",
       "examples": [
         {
-          "text": "should i keep washing my hands"
+          "text": "CDC response"
         },
         {
-          "text": "Should I use soap and water or a hand sanitizer to protect against COVID-19?"
+          "text": "Does CDC work to protect public health?"
         },
         {
-          "text": "how do i wash my hands correctly?"
+          "text": "How is CDC helping Americans prepare?"
         },
         {
-          "text": "will frequent handwashing help?"
+          "text": "What is CDC doing about COVID-19?"
         },
         {
-          "text": "will washing my hands help protect me?"
-        },
-        {
-          "text": "handwashing products"
-        },
-        {
-          "text": "Handwashing tips"
-        },
-        {
-          "text": "is hand sanitizer effective against covid-19?"
+          "text": "What is the center for disease control doing to help?"
         }
       ],
-      "description": "Hand Washing Guidance"
+      "description": "Info about the CDC"
     },
     {
-      "intent": "News_Corona_Virus",
+      "intent": "RiskToPets",
       "examples": [
         {
-          "text": "What is in the NEWS?"
+          "text": "Is there any danger to pets?"
         },
         {
-          "text": "whats happening"
+          "text": "Can corona virus affect the pets?"
         },
         {
-          "text": "NEWS"
+          "text": "Are my pets in risk?"
         },
         {
-          "text": "Whats happening?"
+          "text": "Risk to pets"
+        },
+        {
+          "text": "Should I be concerned about pets or other animals and COVID-19?"
         }
       ],
-      "description": ""
+      "description": "Guidance on potential risk to Pets"
+    },
+    {
+      "intent": "PersonToPerson",
+      "examples": [
+        {
+          "text": "person to person"
+        },
+        {
+          "text": "Can  Corona Virus (COVID-19) spread from person-to-person?"
+        },
+        {
+          "text": "Can someone who has had COVID-19 spread the illness to others?"
+        },
+        {
+          "text": "How does  Corona Virus (COVID-19) spread?"
+        },
+        {
+          "text": "Can I catch it from my friend?"
+        },
+        {
+          "text": "Why is  Corona Virus (COVID-19) spreading between people?"
+        },
+        {
+          "text": "Why is it so contagious?"
+        },
+        {
+          "text": "Who can I get it from?"
+        }
+      ],
+      "description": "Info on how Coronavirus spreads person to person"
+    },
+    {
+      "intent": "spreadinquarantine",
+      "examples": [
+        {
+          "text": "spread in quarantine"
+        },
+        {
+          "text": "what is the incubation period of this corona virus?"
+        },
+        {
+          "text": "Can someone who has been quarantined for COVID-19 spread the illness to others?"
+        },
+        {
+          "text": "does putting infected people into quarantine help?"
+        },
+        {
+          "text": "does quarantining people stop the spread of corona virus?"
+        },
+        {
+          "text": "what is a quarantine?"
+        }
+      ],
+      "description": "does quarantining people stop the spread of corona virus?"
+    },
+    {
+      "intent": "HealthDeptRecommendedActions",
+      "examples": [
+        {
+          "text": "can CDC help my local board of health"
+        },
+        {
+          "text": "how do I ship a specimen to the CDC lab?"
+        },
+        {
+          "text": "can CDC help my local health dept get protective gear?"
+        },
+        {
+          "text": "does CDC provide protocols for labs to test covid-19?"
+        },
+        {
+          "text": "Health dept recommended actions"
+        },
+        {
+          "text": "What should healthcare professionals and health departments do?"
+        }
+      ],
+      "description": "Recommended actions by from the Health Dept"
+    },
+    {
+      "intent": "Testing",
+      "examples": [
+        {
+          "text": "Testing"
+        },
+        {
+          "text": "should I head to the doctor if I show symptoms?"
+        },
+        {
+          "text": "can my doctor test me if I start feeling sick?"
+        },
+        {
+          "text": "who should get tested?"
+        },
+        {
+          "text": "Should I be tested for COVID-19?"
+        }
+      ],
+      "description": "When, where, how of getting yourself tested"
+    },
+    {
+      "intent": "NegativeTestResults",
+      "examples": [
+        {
+          "text": "Can you have corona virus and still test negative?"
+        },
+        {
+          "text": "if you test negative can you still get COVID-19 later?"
+        },
+        {
+          "text": "Can a person test negative and later test positive for COVID-19?"
+        },
+        {
+          "text": "Does a negative test mean a person does not have COVID-19?"
+        },
+        {
+          "text": "Negative test results"
+        }
+      ],
+      "description": "Considerations for receiving negative test results"
+    },
+    {
+      "intent": "ReduceFamilyRisk",
+      "examples": [
+        {
+          "text": "What steps can my family take to reduce our risk of getting COVID-19?"
+        },
+        {
+          "text": "lower my family's risk of getting sick"
+        },
+        {
+          "text": "Reduce family risk"
+        },
+        {
+          "text": "What should I have my family do to keep from getting sick?"
+        },
+        {
+          "text": "what are the top tips to keep my family from catching it?"
+        }
+      ],
+      "description": "Guidance on reducing risk to your family"
+    },
+    {
+      "intent": "HigherRiskPopulations",
+      "examples": [
+        {
+          "text": "Can Millennials get it? "
+        },
+        {
+          "text": "Are older adults more likely to contract the disease?"
+        },
+        {
+          "text": "I have a chronic illness."
+        },
+        {
+          "text": "I have underlying health issues."
+        },
+        {
+          "text": "Why are people with pre-existing conditions more at risk?"
+        },
+        {
+          "text": "Who is dying? "
+        },
+        {
+          "text": "Who is at higher risk for serious illness from COVID-19?"
+        },
+        {
+          "text": "What does immunocompromised mean? "
+        },
+        {
+          "text": "Why do Boomers get sick? "
+        },
+        {
+          "text": "Are all the old people going to die? "
+        },
+        {
+          "text": "I am over the age of 60."
+        },
+        {
+          "text": "How does this impact the elderly? "
+        },
+        {
+          "text": "How does it affect immunocompromised people? "
+        },
+        {
+          "text": "Higher risk populations"
+        },
+        {
+          "text": "Does Gen-Y get it?"
+        },
+        {
+          "text": "Does  Corona Virus (COVID-19) affect older people more?"
+        },
+        {
+          "text": "Do seniors need to take extra precautions?"
+        },
+        {
+          "text": "Can Gen-X get sick? "
+        }
+      ],
+      "description": "Identify which populations are at higher risk"
+    },
+    {
+      "intent": "spreadviafood",
+      "examples": [
+        {
+          "text": "spread via food"
+        },
+        {
+          "text": "does the virus stick to packaged food?"
+        },
+        {
+          "text": "does it spread on food packaging?"
+        },
+        {
+          "text": "Can the virus that causes COVID-19 be spread through food, including refrigerated or frozen food?"
+        },
+        {
+          "text": "do I need to wash my groceries?"
+        }
+      ],
+      "description": "Virus spread from food or food packaging"
     },
     {
       "intent": "DataSource",
       "examples": [
+        {
+          "text": "Where did you learn this?"
+        },
+        {
+          "text": "Is this true?"
+        },
         {
           "text": "Are you sure?"
         },
@@ -86,86 +305,105 @@
         },
         {
           "text": "Where do you get your information?"
-        },
-        {
-          "text": "Where did you learn this?"
-        },
-        {
-          "text": "Is this true?"
         }
       ],
       "description": "Information on where this bot sourced it's data"
     },
     {
-      "intent": "greeting",
+      "intent": "DisinfectingSurfaces",
       "examples": [
         {
-          "text": "heya"
+          "text": "what products are best at disinfecting?"
         },
         {
-          "text": "aloha"
+          "text": "Disinfecting surfaces"
         },
         {
-          "text": "bonjour"
+          "text": "Do I need to clean with bleach?"
         },
         {
-          "text": "buenos dias"
+          "text": "How do I clean my home to remove virus molecules"
         },
         {
-          "text": "ciao"
+          "text": "how should i disinfect my home?"
         },
         {
-          "text": "hello watson"
+          "text": "What cleaning products should I use to protect against COVID-19?"
         },
         {
-          "text": "feeling a bit low"
-        },
-        {
-          "text": "Good morning"
-        },
-        {
-          "text": "Good afternoon"
-        },
-        {
-          "text": "good evening"
-        },
-        {
-          "text": "hey"
-        },
-        {
-          "text": "hello"
-        },
-        {
-          "text": "yo"
-        },
-        {
-          "text": "yello"
-        },
-        {
-          "text": "Olla"
-        },
-        {
-          "text": "namaste"
-        },
-        {
-          "text": "howdy"
-        },
-        {
-          "text": "hi there"
-        },
-        {
-          "text": "hola"
-        },
-        {
-          "text": "hiya"
-        },
-        {
-          "text": "hi"
-        },
-        {
-          "text": "hey there"
+          "text": "Where do i need to disinfect?"
         }
-      ]
+      ],
+      "description": "Disinfection Guidance"
+    },
+    {
+      "intent": "Stigmatizedgroups",
+      "examples": [
+        {
+          "text": "is the pandemic causing discrimination against Chinese people?"
+        },
+        {
+          "text": "Why might someone blame or avoid individuals and groups (create stigma) because of COVID-19?"
+        },
+        {
+          "text": "What causes stereotyping and blame?"
+        },
+        {
+          "text": "Stigmatized groups"
+        },
+        {
+          "text": "are Asian people being unfarely blamed for corona virus?"
+        }
+      ],
+      "description": "About racial discrimination or shaming"
+    },
+    {
+      "intent": "ChildrenSocializing",
+      "examples": [
+        {
+          "text": "do kids need to limit in person contact?"
+        },
+        {
+          "text": "Is social distancing important for kids too?"
+        },
+        {
+          "text": "While school is out can my child go to sports practice?"
+        },
+        {
+          "text": "While school’s out, can my child hang out with their friends?"
+        },
+        {
+          "text": "Can my kid still go to group activities?"
+        },
+        {
+          "text": "Children socializing"
+        }
+      ],
+      "description": "Child Socialization guidance"
+    },
+    {
+      "intent": "Symptoms",
+      "examples": [
+        {
+          "text": "Symptoms"
+        },
+        {
+          "text": "What are the symptoms and complications that COVID-19 can cause?"
+        },
+        {
+          "text": "is fever a sign of this infection?"
+        },
+        {
+          "text": "does covid-19 cause fever?"
+        },
+        {
+          "text": "does covid-19 cause coughing?"
+        },
+        {
+          "text": "what symptoms should I watch for?"
+        }
+      ],
+      "description": "General info on symptoms of covid-19 disease"
     },
     {
       "intent": "HowDoesItSpread",
@@ -189,512 +427,319 @@
       "description": "Info on how COVID Spreads"
     },
     {
-      "intent": "DisinfectingSurfaces",
-      "examples": [
-        {
-          "text": "What cleaning products should I use to protect against COVID-19?"
-        },
-        {
-          "text": "what products are best at disinfecting?"
-        },
-        {
-          "text": "Where do i need to disinfect?"
-        },
-        {
-          "text": "Disinfecting surfaces"
-        },
-        {
-          "text": "Do I need to clean with bleach?"
-        },
-        {
-          "text": "How do I clean my home to remove virus molecules"
-        },
-        {
-          "text": "how should i disinfect my home?"
-        }
-      ],
-      "description": "Disinfection Guidance"
-    },
-    {
-      "intent": "spreadinquarantine",
-      "examples": [
-        {
-          "text": "what is the incubation period of this corona virus?"
-        },
-        {
-          "text": "Can someone who has been quarantined for COVID-19 spread the illness to others?"
-        },
-        {
-          "text": "spread in quarantine"
-        },
-        {
-          "text": "does putting infected people into quarantine help?"
-        },
-        {
-          "text": "what is a quarantine?"
-        },
-        {
-          "text": "does quarantining people stop the spread of corona virus?"
-        }
-      ],
-      "description": "does quarantining people stop the spread of corona virus?"
-    },
-    {
-      "intent": "How_many_cases",
-      "examples": [
-        {
-          "text": "How many cases of covid 19 have been detected?"
-        },
-        {
-          "text": "Total Cases so Far"
-        },
-        {
-          "text": "What are the stats on COVID-19?"
-        },
-        {
-          "text": "What is the stats on Corona Virus?"
-        },
-        {
-          "text": "How many cases of corona virus has been detected?"
-        },
-        {
-          "text": "How many cases of Covid 19 has been detected?"
-        },
-        {
-          "text": "How many cases so far?"
-        }
-      ],
-      "description": "Stats on number of infections"
-    },
-    {
-      "intent": "PersonToPerson",
-      "examples": [
-        {
-          "text": "Why is  Corona Virus (COVID-19) spreading between people?"
-        },
-        {
-          "text": "Why is it so contagious?"
-        },
-        {
-          "text": "Who can I get it from?"
-        },
-        {
-          "text": "person to person"
-        },
-        {
-          "text": "How does  Corona Virus (COVID-19) spread?"
-        },
-        {
-          "text": "Can someone who has had COVID-19 spread the illness to others?"
-        },
-        {
-          "text": "Can I catch it from my friend?"
-        },
-        {
-          "text": "Can  Corona Virus (COVID-19) spread from person-to-person?"
-        }
-      ],
-      "description": "Info on how Coronavirus spreads person to person"
-    },
-    {
-      "intent": "NegativeTestResults",
-      "examples": [
-        {
-          "text": "Can you have corona virus and still test negative?"
-        },
-        {
-          "text": "Negative test results"
-        },
-        {
-          "text": "if you test negative can you still get COVID-19 later?"
-        },
-        {
-          "text": "Does a negative test mean a person does not have COVID-19?"
-        },
-        {
-          "text": "Can a person test negative and later test positive for COVID-19?"
-        }
-      ],
-      "description": "Considerations for receiving negative test results"
-    },
-    {
-      "intent": "ChildrenAndFaceMasks",
-      "examples": [
-        {
-          "text": "can my child play outside without a mask?"
-        },
-        {
-          "text": "Children and facemasks"
-        },
-        {
-          "text": "does my daughter need to wear a facemask?"
-        },
-        {
-          "text": "Should children wear masks?"
-        },
-        {
-          "text": "are facemasks recommended for children"
-        }
-      ],
-      "description": "Guidance regarding Children wearing Facemasks"
-    },
-    {
-      "intent": "ProductsFromChina",
-      "examples": [
-        {
-          "text": "Am I at risk for COVID-19 from a package or products shipping from China?"
-        },
-        {
-          "text": "is it safe to buy Chinese products?"
-        },
-        {
-          "text": "Products from China"
-        },
-        {
-          "text": "should i stop buying products from China?"
-        },
-        {
-          "text": "are packages from China infected?"
-        }
-      ],
-      "description": "Guidance regarding packages from China"
-    },
-    {
-      "intent": "ReportingToWork",
-      "examples": [
-        {
-          "text": "I'm supposed to work but my child's school is canceled"
-        },
-        {
-          "text": "Reporting to work"
-        },
-        {
-          "text": "Should I go to work if there is an outbreak in my community?"
-        },
-        {
-          "text": "what are my work from home options?"
-        },
-        {
-          "text": "will my office be closed?"
-        }
-      ],
-      "description": "Guidance on going in to work"
-    },
-    {
-      "intent": "ChildrenSocializing",
-      "examples": [
-        {
-          "text": "Children socializing"
-        },
-        {
-          "text": "do kids need to limit in person contact?"
-        },
-        {
-          "text": "Is social distancing important for kids too?"
-        },
-        {
-          "text": "While school is out can my child go to sports practice?"
-        },
-        {
-          "text": "While school’s out, can my child hang out with their friends?"
-        },
-        {
-          "text": "Can my kid still go to group activities?"
-        }
-      ],
-      "description": "Child Socialization guidance"
-    },
-    {
-      "intent": "RiskToPets",
-      "examples": [
-        {
-          "text": "Is there any danger to pets?"
-        },
-        {
-          "text": "Can corona virus affect the pets?"
-        },
-        {
-          "text": "Are my pets in risk?"
-        },
-        {
-          "text": "Should I be concerned about pets or other animals and COVID-19?"
-        },
-        {
-          "text": "Risk to pets"
-        }
-      ],
-      "description": "Guidance on potential risk to Pets"
-    },
-    {
       "intent": "Wearingfacemasks",
       "examples": [
-        {
-          "text": "Do I need to wear a face mask?"
-        },
         {
           "text": "What do face masks do? "
         },
         {
-          "text": "Wearing face masks"
-        },
-        {
-          "text": "Someone in my household is sick should we wear masks at home?"
-        },
-        {
-          "text": "Should my child wear a face mask?"
-        },
-        {
-          "text": "Should I wear a face mask?"
-        },
-        {
-          "text": "Should I use a face mask when in public?"
+          "text": "Do face masks do anything?"
         },
         {
           "text": "Does CDC recommend the use of facemask to prevent COVID-19?"
         },
         {
-          "text": "Do face masks do anything?"
+          "text": "Should I use a face mask when in public?"
+        },
+        {
+          "text": "Should I wear a face mask?"
+        },
+        {
+          "text": "Should my child wear a face mask?"
+        },
+        {
+          "text": "Someone in my household is sick should we wear masks at home?"
+        },
+        {
+          "text": "Wearing face masks"
+        },
+        {
+          "text": "Do I need to wear a face mask?"
         }
       ],
       "description": "General facemask questions"
     },
     {
-      "intent": "warmerweather",
+      "intent": "USinfectionlevel",
       "examples": [
         {
-          "text": "Will warm weather stop the outbreak of COVID-19?"
+          "text": "US infection level"
         },
         {
-          "text": "will the virus go away during warmer months?"
+          "text": "Are there any confirmed case in the US?"
         },
         {
-          "text": "warmer weather"
+          "text": "How many people recovered in America?"
         },
         {
-          "text": "does it get less contagious in the summer?"
+          "text": "How many cases are there in the United States?"
         },
         {
-          "text": "i heard the spread will slow down in warmer months"
+          "text": "How many cases in the U.S.?"
+        },
+        {
+          "text": "How many deaths in the US?"
+        },
+        {
+          "text": "How many recovered in the United States?"
+        },
+        {
+          "text": "How many people have died in the U.S.? "
+        },
+        {
+          "text": "Has anyone in the United States gotten infected?"
+        },
+        {
+          "text": "How many people in the U.S. have  Corona Virus (COVID-19)?"
+        },
+        {
+          "text": "What is the total number of deaths in the US?"
+        },
+        {
+          "text": "What is the status of US cases?"
+        },
+        {
+          "text": "How many infected people are there in America? "
+        },
+        {
+          "text": "How many cases are there in America?"
         }
       ],
-      "description": "Does warmer weather or summer weather have an effect on the virus or the pandemic"
+      "description": "National stats"
     },
     {
-      "intent": "Symptomsinchildren",
+      "intent": "goodbyes",
       "examples": [
         {
-          "text": "do kids get different symptoms?"
+          "text": "farewell"
         },
         {
-          "text": "do children react differently to the virus than adults do?"
+          "text": "stop"
         },
         {
-          "text": "Are the symptoms of COVID-19 different in children than in adults?"
+          "text": "ok thank you"
         },
         {
-          "text": "Symptoms in children"
+          "text": "ok thank you for your time"
         },
         {
-          "text": "what are the symptoms in children?"
+          "text": "ok thanks"
+        },
+        {
+          "text": "o thank u"
+        },
+        {
+          "text": "i am done with you"
+        },
+        {
+          "text": "bye im going to play a game"
+        },
+        {
+          "text": "thx"
+        },
+        {
+          "text": "ty"
+        },
+        {
+          "text": "ttyl"
+        },
+        {
+          "text": "thanks"
+        },
+        {
+          "text": "toodles"
+        },
+        {
+          "text": "then bye"
+        },
+        {
+          "text": "thank you"
+        },
+        {
+          "text": "thanks watson"
+        },
+        {
+          "text": "talk to you later"
+        },
+        {
+          "text": "talk to you soon"
+        },
+        {
+          "text": "take it easy"
+        },
+        {
+          "text": "take care"
+        },
+        {
+          "text": "soon"
+        },
+        {
+          "text": "so long"
+        },
+        {
+          "text": "signing out"
+        },
+        {
+          "text": "signing off"
+        },
+        {
+          "text": "should go"
+        },
+        {
+          "text": "should be going"
+        },
+        {
+          "text": "see you later"
+        },
+        {
+          "text": "see you"
+        },
+        {
+          "text": "later"
+        },
+        {
+          "text": "im leaving"
+        },
+        {
+          "text": "have a good one"
+        },
+        {
+          "text": "gtg"
+        },
+        {
+          "text": "gotta run"
+        },
+        {
+          "text": "gotta go"
+        },
+        {
+          "text": "gday"
+        },
+        {
+          "text": "good day"
+        },
+        {
+          "text": "good bye"
+        },
+        {
+          "text": "goodbye"
+        },
+        {
+          "text": "go"
+        },
+        {
+          "text": "cya"
+        },
+        {
+          "text": "catch ya later"
+        },
+        {
+          "text": "bye now"
+        },
+        {
+          "text": "bye bye"
+        },
+        {
+          "text": "bye"
+        },
+        {
+          "text": "au revoir"
+        },
+        {
+          "text": "adios"
+        },
+        {
+          "text": "adieu"
+        },
+        {
+          "text": "good night"
+        },
+        {
+          "text": "g'day"
+        },
+        {
+          "text": "i'm leaving"
+        },
+        {
+          "text": "youre welcome now bye"
+        },
+        {
+          "text": "no problem"
+        },
+        {
+          "text": "thank you for the info"
+        },
+        {
+          "text": "sorry got to go"
+        },
+        {
+          "text": "gtg go right now ok"
+        },
+        {
+          "text": "got to go bye nice time talking to you"
+        },
+        {
+          "text": "goodbye joto"
+        },
+        {
+          "text": "good bye hohoho"
+        },
+        {
+          "text": "dont need your help at all"
+        },
+        {
+          "text": "done"
+        },
+        {
+          "text": "be quiet robot"
+        },
+        {
+          "text": "thanks for your help"
+        },
+        {
+          "text": "shut up"
+        },
+        {
+          "text": "see ya soon"
+        },
+        {
+          "text": "see ya later"
+        },
+        {
+          "text": "see ya"
+        },
+        {
+          "text": "run"
+        },
+        {
+          "text": "over and out"
+        },
+        {
+          "text": "out of time"
+        },
+        {
+          "text": "ok bye"
+        },
+        {
+          "text": "my time is up"
+        },
+        {
+          "text": "logging off"
+        },
+        {
+          "text": "leave"
+        },
+        {
+          "text": "laters"
+        },
+        {
+          "text": "no thank you"
         }
-      ],
-      "description": "Signs and symptoms in children and differences from adults"
-    },
-    {
-      "intent": "ReduceFamilyRisk",
-      "examples": [
-        {
-          "text": "lower my family's risk of getting sick"
-        },
-        {
-          "text": "What steps can my family take to reduce our risk of getting COVID-19?"
-        },
-        {
-          "text": "Reduce family risk"
-        },
-        {
-          "text": "what are the top tips to keep my family from catching it?"
-        },
-        {
-          "text": "What should I have my family do to keep from getting sick?"
-        }
-      ],
-      "description": "Guidance on reducing risk to your family"
-    },
-    {
-      "intent": "HigherRiskPopulations",
-      "examples": [
-        {
-          "text": "I am over the age of 60."
-        },
-        {
-          "text": "How does this impact the elderly? "
-        },
-        {
-          "text": "How does it affect immunocompromised people? "
-        },
-        {
-          "text": "Higher risk populations"
-        },
-        {
-          "text": "Does Gen-Y get it?"
-        },
-        {
-          "text": "Does  Corona Virus (COVID-19) affect older people more?"
-        },
-        {
-          "text": "Do seniors need to take extra precautions?"
-        },
-        {
-          "text": "Can Millennials get it? "
-        },
-        {
-          "text": "Can Gen-X get sick? "
-        },
-        {
-          "text": "Are older adults more likely to contract the disease?"
-        },
-        {
-          "text": "Are all the old people going to die? "
-        },
-        {
-          "text": "Why do Boomers get sick? "
-        },
-        {
-          "text": "What does immunocompromised mean? "
-        },
-        {
-          "text": "Who is at higher risk for serious illness from COVID-19?"
-        },
-        {
-          "text": "Who is dying? "
-        },
-        {
-          "text": "Why are people with pre-existing conditions more at risk?"
-        },
-        {
-          "text": "I have underlying health issues."
-        },
-        {
-          "text": "I have a chronic illness."
-        }
-      ],
-      "description": "Identify which populations are at higher risk"
-    },
-    {
-      "intent": "Stigmatizedgroups",
-      "examples": [
-        {
-          "text": "Stigmatized groups"
-        },
-        {
-          "text": "are Asian people being unfarely blamed for corona virus?"
-        },
-        {
-          "text": "is the pandemic causing discrimination against Chinese people?"
-        },
-        {
-          "text": "Why might someone blame or avoid individuals and groups (create stigma) because of COVID-19?"
-        },
-        {
-          "text": "What causes stereotyping and blame?"
-        }
-      ],
-      "description": "About racial discrimination or shaming"
-    },
-    {
-      "intent": "Wherediditstart",
-      "examples": [
-        {
-          "text": "What is the source of the virus?"
-        },
-        {
-          "text": "which location did corona virus start from?"
-        },
-        {
-          "text": "Where did it start"
-        },
-        {
-          "text": "Where did corona virus originate from?"
-        }
-      ],
-      "description": "Handle questions about the origins of the virus in humans"
-    },
-    {
-      "intent": "Testing",
-      "examples": [
-        {
-          "text": "Should I be tested for COVID-19?"
-        },
-        {
-          "text": "who should get tested?"
-        },
-        {
-          "text": "Testing"
-        },
-        {
-          "text": "should I head to the doctor if I show symptoms?"
-        },
-        {
-          "text": "can my doctor test me if I start feeling sick?"
-        }
-      ],
-      "description": "When, where, how of getting yourself tested"
-    },
-    {
-      "intent": "RiskToChildren",
-      "examples": [
-        {
-          "text": "Risk to children"
-        },
-        {
-          "text": "do children catch covid-19?"
-        },
-        {
-          "text": "Are children at higher risk of getting sick?"
-        },
-        {
-          "text": "What is the risk of my child becoming sick with COVID-19?"
-        },
-        {
-          "text": "Can corona virus infect an infant?"
-        },
-        {
-          "text": "Are kids at increased risk of infection?"
-        }
-      ],
-      "description": "Guidance on potential risk to Children"
-    },
-    {
-      "intent": "MealsForStudents",
-      "examples": [
-        {
-          "text": "will school students be able to get their free meals?"
-        },
-        {
-          "text": "While school’s out, will kids have access to meals?"
-        },
-        {
-          "text": "Meals for students"
-        },
-        {
-          "text": "how are students on school lunch plans getting their meals?"
-        },
-        {
-          "text": "are schools continuing to serve school lunch plans even if classes are closed?"
-        }
-      ],
-      "description": "Info regarding school and student meals"
+      ]
     },
     {
       "intent": "schoolclosing",
       "examples": [
-        {
-          "text": "how do I know if my school is closing?"
-        },
-        {
-          "text": "Will schools be dismissed if there is an outbreak in my community?"
-        },
         {
           "text": "why are schools closing?"
         },
@@ -703,450 +748,109 @@
         },
         {
           "text": "school closing"
+        },
+        {
+          "text": "how do I know if my school is closing?"
+        },
+        {
+          "text": "Will schools be dismissed if there is an outbreak in my community?"
         }
       ],
       "description": "School closings information"
     },
     {
+      "intent": "How_many_cases",
+      "examples": [
+        {
+          "text": "What is the stats on Corona Virus?"
+        },
+        {
+          "text": "How many cases of corona virus has been detected?"
+        },
+        {
+          "text": "How many cases so far?"
+        },
+        {
+          "text": "How many cases of Covid 19 has been detected?"
+        },
+        {
+          "text": "How many cases of covid 19 have been detected?"
+        },
+        {
+          "text": "Total Cases so Far"
+        },
+        {
+          "text": "What are the stats on COVID-19?"
+        }
+      ],
+      "description": "Stats on number of infections"
+    },
+    {
+      "intent": "ChildrenAndFaceMasks",
+      "examples": [
+        {
+          "text": "does my daughter need to wear a facemask?"
+        },
+        {
+          "text": "are facemasks recommended for children"
+        },
+        {
+          "text": "can my child play outside without a mask?"
+        },
+        {
+          "text": "Children and facemasks"
+        },
+        {
+          "text": "Should children wear masks?"
+        }
+      ],
+      "description": "Guidance regarding Children wearing Facemasks"
+    },
+    {
       "intent": "CommunitySpread",
       "examples": [
         {
-          "text": "Can community spread happen? "
-        },
-        {
           "text": "Community Spread"
-        },
-        {
-          "text": "Does  Corona Virus (COVID-19) spread to an entire community?"
-        },
-        {
-          "text": "How does community spread happen? "
         },
         {
           "text": "What does that term community spread mean?"
         },
         {
-          "text": "What is community spread?"
+          "text": "How does community spread happen? "
+        },
+        {
+          "text": "Does  Corona Virus (COVID-19) spread to an entire community?"
         },
         {
           "text": "Why is community spread of this virus important?"
+        },
+        {
+          "text": "What is community spread?"
+        },
+        {
+          "text": "Can community spread happen? "
         }
       ],
       "description": "Defining Community Spread"
     },
     {
-      "intent": "AttendingFuneral",
-      "examples": [
-        {
-          "text": "Can I go to a funeral? "
-        },
-        {
-          "text": "Can I go to a funeral of someone who died of  Corona Virus (COVID-19)?"
-        },
-        {
-          "text": "Are funerals safe? "
-        },
-        {
-          "text": "Am I at risk if I go to a funeral or visitation service for someone who died of COVID-19?"
-        },
-        {
-          "text": "Should I avoid funerals?"
-        }
-      ],
-      "description": "Funeral attendance guidance"
-    },
-    {
-      "intent": "Symptoms",
-      "examples": [
-        {
-          "text": "What are the symptoms and complications that COVID-19 can cause?"
-        },
-        {
-          "text": "is fever a sign of this infection?"
-        },
-        {
-          "text": "does covid-19 cause fever?"
-        },
-        {
-          "text": "does covid-19 cause coughing?"
-        },
-        {
-          "text": "what symptoms should I watch for?"
-        },
-        {
-          "text": "Symptoms"
-        }
-      ],
-      "description": "General info on symptoms of covid-19 disease"
-    },
-    {
-      "intent": "HealthDeptRecommendedActions",
-      "examples": [
-        {
-          "text": "how do I ship a specimen to the CDC lab?"
-        },
-        {
-          "text": "What should healthcare professionals and health departments do?"
-        },
-        {
-          "text": "Health dept recommended actions"
-        },
-        {
-          "text": "does CDC provide protocols for labs to test covid-19?"
-        },
-        {
-          "text": "can CDC help my local health dept get protective gear?"
-        },
-        {
-          "text": "can CDC help my local board of health"
-        }
-      ],
-      "description": "Recommended actions by from the Health Dept"
-    },
-    {
-      "intent": "USinfectionlevel",
-      "examples": [
-        {
-          "text": "Are there any confirmed case in the US?"
-        },
-        {
-          "text": "How many cases are there in America?"
-        },
-        {
-          "text": "How many infected people are there in America? "
-        },
-        {
-          "text": "What is the status of US cases?"
-        },
-        {
-          "text": "What is the total number of deaths in the US?"
-        },
-        {
-          "text": "How many people in the U.S. have  Corona Virus (COVID-19)?"
-        },
-        {
-          "text": "Has anyone in the United States gotten infected?"
-        },
-        {
-          "text": "How many people have died in the U.S.? "
-        },
-        {
-          "text": "How many deaths in the US?"
-        },
-        {
-          "text": "How many cases in the U.S.?"
-        },
-        {
-          "text": "How many cases are there in the United States?"
-        },
-        {
-          "text": "How many people recovered in America?"
-        },
-        {
-          "text": "How many recovered in the United States?"
-        },
-        {
-          "text": "US infection level"
-        }
-      ],
-      "description": "National stats"
-    },
-    {
-      "intent": "InfectedFamilyMember",
-      "examples": [
-        {
-          "text": "what do i do when someone in my home gets it?"
-        },
-        {
-          "text": "my roommate has corona virus what should I do?"
-        },
-        {
-          "text": "What should I do if someone in my house gets sick with COVID-19?"
-        },
-        {
-          "text": "do I need to quarantine ill family members?"
-        },
-        {
-          "text": "Infected family member"
-        }
-      ],
-      "description": "Guidance if a Family Member is infected"
-    },
-    {
-      "intent": "goodbyes",
-      "examples": [
-        {
-          "text": "no thank you"
-        },
-        {
-          "text": "laters"
-        },
-        {
-          "text": "leave"
-        },
-        {
-          "text": "logging off"
-        },
-        {
-          "text": "my time is up"
-        },
-        {
-          "text": "ok bye"
-        },
-        {
-          "text": "out of time"
-        },
-        {
-          "text": "over and out"
-        },
-        {
-          "text": "run"
-        },
-        {
-          "text": "see ya"
-        },
-        {
-          "text": "see ya later"
-        },
-        {
-          "text": "see ya soon"
-        },
-        {
-          "text": "shut up"
-        },
-        {
-          "text": "thanks for your help"
-        },
-        {
-          "text": "be quiet robot"
-        },
-        {
-          "text": "done"
-        },
-        {
-          "text": "dont need your help at all"
-        },
-        {
-          "text": "good bye hohoho"
-        },
-        {
-          "text": "goodbye joto"
-        },
-        {
-          "text": "got to go bye nice time talking to you"
-        },
-        {
-          "text": "gtg go right now ok"
-        },
-        {
-          "text": "sorry got to go"
-        },
-        {
-          "text": "thank you for the info"
-        },
-        {
-          "text": "no problem"
-        },
-        {
-          "text": "youre welcome now bye"
-        },
-        {
-          "text": "i'm leaving"
-        },
-        {
-          "text": "g'day"
-        },
-        {
-          "text": "good night"
-        },
-        {
-          "text": "adieu"
-        },
-        {
-          "text": "adios"
-        },
-        {
-          "text": "au revoir"
-        },
-        {
-          "text": "bye"
-        },
-        {
-          "text": "bye bye"
-        },
-        {
-          "text": "bye now"
-        },
-        {
-          "text": "catch ya later"
-        },
-        {
-          "text": "cya"
-        },
-        {
-          "text": "farewell"
-        },
-        {
-          "text": "go"
-        },
-        {
-          "text": "goodbye"
-        },
-        {
-          "text": "good bye"
-        },
-        {
-          "text": "good day"
-        },
-        {
-          "text": "gday"
-        },
-        {
-          "text": "gotta go"
-        },
-        {
-          "text": "gotta run"
-        },
-        {
-          "text": "gtg"
-        },
-        {
-          "text": "have a good one"
-        },
-        {
-          "text": "im leaving"
-        },
-        {
-          "text": "later"
-        },
-        {
-          "text": "see you"
-        },
-        {
-          "text": "see you later"
-        },
-        {
-          "text": "should be going"
-        },
-        {
-          "text": "should go"
-        },
-        {
-          "text": "signing off"
-        },
-        {
-          "text": "signing out"
-        },
-        {
-          "text": "so long"
-        },
-        {
-          "text": "soon"
-        },
-        {
-          "text": "take care"
-        },
-        {
-          "text": "take it easy"
-        },
-        {
-          "text": "talk to you soon"
-        },
-        {
-          "text": "talk to you later"
-        },
-        {
-          "text": "thanks watson"
-        },
-        {
-          "text": "thank you"
-        },
-        {
-          "text": "then bye"
-        },
-        {
-          "text": "toodles"
-        },
-        {
-          "text": "thanks"
-        },
-        {
-          "text": "ttyl"
-        },
-        {
-          "text": "ty"
-        },
-        {
-          "text": "thx"
-        },
-        {
-          "text": "bye im going to play a game"
-        },
-        {
-          "text": "i am done with you"
-        },
-        {
-          "text": "o thank u"
-        },
-        {
-          "text": "ok thanks"
-        },
-        {
-          "text": "ok thank you for your time"
-        },
-        {
-          "text": "ok thank you"
-        },
-        {
-          "text": "stop"
-        }
-      ]
-    },
-    {
-      "intent": "spreadviafood",
-      "examples": [
-        {
-          "text": "spread via food"
-        },
-        {
-          "text": "do I need to wash my groceries?"
-        },
-        {
-          "text": "Can the virus that causes COVID-19 be spread through food, including refrigerated or frozen food?"
-        },
-        {
-          "text": "does it spread on food packaging?"
-        },
-        {
-          "text": "does the virus stick to packaged food?"
-        }
-      ],
-      "description": "Virus spread from food or food packaging"
-    },
-    {
-      "intent": "PrepareFamily",
-      "examples": [
-        {
-          "text": "Prepare family"
-        },
-        {
-          "text": "How can my family and I prepare for COVID-19?"
-        },
-        {
-          "text": "should my household plan ahead?"
-        },
-        {
-          "text": "what goes into a family emergency plan?"
-        },
-        {
-          "text": "how do I prepare my household in case corona virus hits my community?"
-        }
-      ],
-      "description": "Family Preparation Guidance"
-    },
-    {
       "intent": "WhatisCovid",
       "examples": [
+        {
+          "text": "What is a novel coronavirus?"
+        },
+        {
+          "text": "What is Covid"
+        },
+        {
+          "text": "What is COVID 19?"
+        },
+        {
+          "text": "What is SARS-CoV-2?"
+        },
+        {
+          "text": "When did  Corona Virus (COVID-19) appear?"
+        },
         {
           "text": "How did the  Corona Virus (COVID-19) spread from China?"
         },
@@ -1154,68 +858,92 @@
           "text": "covid 19"
         },
         {
-          "text": "Carona Virus"
-        },
-        {
-          "text": "When did  Corona Virus (COVID-19) appear?"
-        },
-        {
-          "text": "What is SARS-CoV-2?"
-        },
-        {
-          "text": "What is COVID 19?"
-        },
-        {
-          "text": "What is Covid"
-        },
-        {
-          "text": "what is carona virus?"
-        },
-        {
-          "text": "What is a novel coronavirus?"
-        },
-        {
-          "text": "When did  Corona Virus (COVID-19) start?"
-        },
-        {
-          "text": "Where did  Corona Virus (COVID-19) appear?"
+          "text": "Why did  Corona Virus (COVID-19) spread?"
         },
         {
           "text": "Where was  Corona Virus (COVID-19) first spotted."
         },
         {
-          "text": "Why did  Corona Virus (COVID-19) spread?"
+          "text": "Where did  Corona Virus (COVID-19) appear?"
+        },
+        {
+          "text": "When did  Corona Virus (COVID-19) start?"
+        },
+        {
+          "text": "Carona Virus"
+        },
+        {
+          "text": "what is carona virus?"
         }
       ],
       "description": "Description and definition of COVID19"
     },
     {
-      "intent": "ProtectingChildren",
+      "intent": "PreparingChildren",
       "examples": [
         {
-          "text": "what will protect my kids from getting the infection?"
+          "text": "how do I keep my kids from worrying about the virus?"
         },
         {
-          "text": "How can I protect my child from COVID-19 infection?"
+          "text": "what should I tell my child about this pandemic?"
         },
         {
-          "text": "should I disinfect my kid's toys?"
+          "text": "Preparing children"
         },
         {
-          "text": "Protecting children"
+          "text": "My child is stressed about the crisis how can I help?"
         },
         {
-          "text": "is handwashing important for children?"
+          "text": "How do I prepare my children in case of COVID-19 outbreak in our community?"
         }
       ],
-      "description": "Guidance for keeping children protected"
+      "description": "Guidance for calming and protecting children"
+    },
+    {
+      "intent": "Symptomsinchildren",
+      "examples": [
+        {
+          "text": "Symptoms in children"
+        },
+        {
+          "text": "Are the symptoms of COVID-19 different in children than in adults?"
+        },
+        {
+          "text": "do children react differently to the virus than adults do?"
+        },
+        {
+          "text": "do kids get different symptoms?"
+        },
+        {
+          "text": "what are the symptoms in children?"
+        }
+      ],
+      "description": "Signs and symptoms in children and differences from adults"
+    },
+    {
+      "intent": "warmerweather",
+      "examples": [
+        {
+          "text": "i heard the spread will slow down in warmer months"
+        },
+        {
+          "text": "warmer weather"
+        },
+        {
+          "text": "will the virus go away during warmer months?"
+        },
+        {
+          "text": "Will warm weather stop the outbreak of COVID-19?"
+        },
+        {
+          "text": "does it get less contagious in the summer?"
+        }
+      ],
+      "description": "Does warmer weather or summer weather have an effect on the virus or the pandemic"
     },
     {
       "intent": "AnimalContact",
       "examples": [
-        {
-          "text": "can I get this from my dog?"
-        },
         {
           "text": "can my dog catch corona virus?"
         },
@@ -1233,55 +961,186 @@
         },
         {
           "text": "do dogs and cats get sick from corona virus?"
+        },
+        {
+          "text": "can I get this from my dog?"
         }
       ],
       "description": "Human - Animal interaction guidance"
     },
     {
-      "intent": "CDC_Response",
+      "intent": "InfectedFamilyMember",
       "examples": [
         {
-          "text": "CDC response"
+          "text": "what do i do when someone in my home gets it?"
         },
         {
-          "text": "What is the center for disease control doing to help?"
+          "text": "Infected family member"
         },
         {
-          "text": "What is CDC doing about COVID-19?"
+          "text": "do I need to quarantine ill family members?"
         },
         {
-          "text": "How is CDC helping Americans prepare?"
+          "text": "What should I do if someone in my house gets sick with COVID-19?"
         },
         {
-          "text": "Does CDC work to protect public health?"
+          "text": "my roommate has corona virus what should I do?"
         }
       ],
-      "description": "Info about the CDC"
+      "description": "Guidance if a Family Member is infected"
     },
     {
-      "intent": "PreparingChildren",
+      "intent": "MealsForStudents",
       "examples": [
         {
-          "text": "how do I keep my kids from worrying about the virus?"
+          "text": "While school’s out, will kids have access to meals?"
         },
         {
-          "text": "How do I prepare my children in case of COVID-19 outbreak in our community?"
+          "text": "Meals for students"
         },
         {
-          "text": "My child is stressed about the crisis how can I help?"
+          "text": "how are students on school lunch plans getting their meals?"
         },
         {
-          "text": "Preparing children"
+          "text": "are schools continuing to serve school lunch plans even if classes are closed?"
         },
         {
-          "text": "what should I tell my child about this pandemic?"
+          "text": "will school students be able to get their free meals?"
         }
       ],
-      "description": "Guidance for calming and protecting children"
+      "description": "Info regarding school and student meals"
+    },
+    {
+      "intent": "greeting",
+      "examples": [
+        {
+          "text": "Good morning"
+        },
+        {
+          "text": "howdy"
+        },
+        {
+          "text": "hey"
+        },
+        {
+          "text": "hiya"
+        },
+        {
+          "text": "hi"
+        },
+        {
+          "text": "hey there"
+        },
+        {
+          "text": "feeling a bit low"
+        },
+        {
+          "text": "hello watson"
+        },
+        {
+          "text": "good evening"
+        },
+        {
+          "text": "Good afternoon"
+        },
+        {
+          "text": "ciao"
+        },
+        {
+          "text": "buenos dias"
+        },
+        {
+          "text": "bonjour"
+        },
+        {
+          "text": "aloha"
+        },
+        {
+          "text": "heya"
+        },
+        {
+          "text": "hello"
+        },
+        {
+          "text": "yo"
+        },
+        {
+          "text": "yello"
+        },
+        {
+          "text": "Olla"
+        },
+        {
+          "text": "namaste"
+        },
+        {
+          "text": "hi there"
+        },
+        {
+          "text": "hola"
+        }
+      ]
+    },
+    {
+      "intent": "HandwashingTips",
+      "examples": [
+        {
+          "text": "is hand sanitizer effective against covid-19?"
+        },
+        {
+          "text": "Should I use soap and water or a hand sanitizer to protect against COVID-19?"
+        },
+        {
+          "text": "should i keep washing my hands"
+        },
+        {
+          "text": "will washing my hands help protect me?"
+        },
+        {
+          "text": "handwashing products"
+        },
+        {
+          "text": "Handwashing tips"
+        },
+        {
+          "text": "how do i wash my hands correctly?"
+        },
+        {
+          "text": "will frequent handwashing help?"
+        }
+      ],
+      "description": "Hand Washing Guidance"
+    },
+    {
+      "intent": "ProductsFromChina",
+      "examples": [
+        {
+          "text": "Products from China"
+        },
+        {
+          "text": "is it safe to buy Chinese products?"
+        },
+        {
+          "text": "Am I at risk for COVID-19 from a package or products shipping from China?"
+        },
+        {
+          "text": "are packages from China infected?"
+        },
+        {
+          "text": "should i stop buying products from China?"
+        }
+      ],
+      "description": "Guidance regarding packages from China"
     },
     {
       "intent": "Schoolfromhome",
       "examples": [
+        {
+          "text": "School from home"
+        },
+        {
+          "text": "how do I keep my child engaged in schoolwork?"
+        },
         {
           "text": "While school’s out, how can I help my child continue learning?"
         },
@@ -1289,19 +1148,172 @@
           "text": "Tips for my child's schedule when school is canceled."
         },
         {
-          "text": "School from home"
-        },
-        {
           "text": "I need tips for at home learning"
-        },
-        {
-          "text": "how do I keep my child engaged in schoolwork?"
         }
       ],
       "description": "Conducting remote education while school is dismissed"
+    },
+    {
+      "intent": "AttendingFuneral",
+      "examples": [
+        {
+          "text": "Are funerals safe? "
+        },
+        {
+          "text": "Can I go to a funeral of someone who died of  Corona Virus (COVID-19)?"
+        },
+        {
+          "text": "Can I go to a funeral? "
+        },
+        {
+          "text": "Should I avoid funerals?"
+        },
+        {
+          "text": "Am I at risk if I go to a funeral or visitation service for someone who died of COVID-19?"
+        }
+      ],
+      "description": "Funeral attendance guidance"
+    },
+    {
+      "intent": "ReportingToWork",
+      "examples": [
+        {
+          "text": "will my office be closed?"
+        },
+        {
+          "text": "I'm supposed to work but my child's school is canceled"
+        },
+        {
+          "text": "Reporting to work"
+        },
+        {
+          "text": "Should I go to work if there is an outbreak in my community?"
+        },
+        {
+          "text": "what are my work from home options?"
+        }
+      ],
+      "description": "Guidance on going in to work"
+    },
+    {
+      "intent": "ProtectingChildren",
+      "examples": [
+        {
+          "text": "How can I protect my child from COVID-19 infection?"
+        },
+        {
+          "text": "is handwashing important for children?"
+        },
+        {
+          "text": "Protecting children"
+        },
+        {
+          "text": "should I disinfect my kid's toys?"
+        },
+        {
+          "text": "what will protect my kids from getting the infection?"
+        }
+      ],
+      "description": "Guidance for keeping children protected"
+    },
+    {
+      "intent": "Whythename",
+      "examples": [
+        {
+          "text": "is corona virus the same as covid-19?"
+        },
+        {
+          "text": "why is covid-19 the name for this disease?"
+        },
+        {
+          "text": "Why is the disease being called coronavirus disease 2019, COVID-19?"
+        },
+        {
+          "text": "why was covid-19 used to name this disease?"
+        },
+        {
+          "text": "Why the name"
+        },
+        {
+          "text": "is covid an abbreviation?"
+        }
+      ],
+      "description": "Answer how the name for this virus and disease arose."
+    },
+    {
+      "intent": "RiskToChildren",
+      "examples": [
+        {
+          "text": "do children catch covid-19?"
+        },
+        {
+          "text": "Risk to children"
+        },
+        {
+          "text": "Are children at higher risk of getting sick?"
+        },
+        {
+          "text": "What is the risk of my child becoming sick with COVID-19?"
+        },
+        {
+          "text": "Are kids at increased risk of infection?"
+        },
+        {
+          "text": "Can corona virus infect an infant?"
+        }
+      ],
+      "description": "Guidance on potential risk to Children"
+    },
+    {
+      "intent": "News_Corona_Virus",
+      "examples": [
+        {
+          "text": "NEWS"
+        },
+        {
+          "text": "What is in the NEWS?"
+        },
+        {
+          "text": "whats happening"
+        },
+        {
+          "text": "Whats happening?"
+        }
+      ],
+      "description": ""
+    },
+    {
+      "intent": "Wherediditstart",
+      "examples": [
+        {
+          "text": "Where did it start"
+        },
+        {
+          "text": "which location did corona virus start from?"
+        },
+        {
+          "text": "What is the source of the virus?"
+        },
+        {
+          "text": "Where did corona virus originate from?"
+        }
+      ],
+      "description": "Handle questions about the origins of the virus in humans"
     }
   ],
   "entities": [
+    {
+      "entity": "zip_code",
+      "values": [
+        {
+          "type": "patterns",
+          "value": "@sys-number",
+          "patterns": [
+            "(\\b|\\s)\\d{5}(\\b|\\s)"
+          ]
+        }
+      ]
+    },
     {
       "entity": "reply",
       "values": [
@@ -1339,8 +1351,62 @@
       ]
     },
     {
-      "entity": "sys-location",
+      "entity": "school_type",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "college",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "grade school",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "middle school",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "high school",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "preschool",
+          "synonyms": []
+        }
+      ]
+    },
+    {
+      "entity": "sys-number",
       "values": [],
+      "fuzzy_match": true
+    },
+    {
+      "entity": "coronavirus",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "coronavirus",
+          "synonyms": [
+            "corona",
+            "virus check",
+            "virus",
+            "COVID-19",
+            "COVID",
+            "coronavirus",
+            "corona-virus",
+            "carona-virus",
+            "Carona",
+            "Korona",
+            "Korona-virus",
+            "COVID19"
+          ]
+        }
+      ],
       "fuzzy_match": true
     },
     {
@@ -1383,78 +1449,12 @@
       ]
     },
     {
-      "entity": "coronavirus",
-      "values": [
-        {
-          "type": "synonyms",
-          "value": "coronavirus",
-          "synonyms": [
-            "corona",
-            "virus check",
-            "virus",
-            "COVID-19",
-            "COVID",
-            "coronavirus",
-            "corona-virus",
-            "carona-virus",
-            "Carona",
-            "Korona",
-            "Korona-virus",
-            "COVID19"
-          ]
-        }
-      ],
-      "fuzzy_match": true
-    },
-    {
       "entity": "sys-person",
       "values": [],
       "fuzzy_match": true
     },
     {
-      "entity": "school_type",
-      "values": [
-        {
-          "type": "synonyms",
-          "value": "grade school",
-          "synonyms": []
-        },
-        {
-          "type": "synonyms",
-          "value": "middle school",
-          "synonyms": []
-        },
-        {
-          "type": "synonyms",
-          "value": "college",
-          "synonyms": []
-        },
-        {
-          "type": "synonyms",
-          "value": "preschool",
-          "synonyms": []
-        },
-        {
-          "type": "synonyms",
-          "value": "high school",
-          "synonyms": []
-        }
-      ]
-    },
-    {
-      "entity": "zip_code",
-      "values": [
-        {
-          "type": "patterns",
-          "value": "@sys-number",
-          "patterns": [
-            "(\\b|\\s)\\d{5}(\\b|\\s)"
-          ]
-        }
-      ]
-    },
-    {
-      "entity": "sys-number",
+      "entity": "sys-location",
       "values": [],
       "fuzzy_match": true
     }
@@ -1473,284 +1473,6 @@
     }
   ],
   "dialog_nodes": [
-    {
-      "type": "event_handler",
-      "output": {
-        "text": {
-          "values": [
-            "What country would you like the stats for?"
-          ],
-          "selection_policy": "sequential"
-        }
-      },
-      "parent": "slot_9_1585096776672",
-      "event_name": "focus",
-      "dialog_node": "handler_10_1585096776761",
-      "previous_sibling": "handler_2_1585096776761"
-    },
-    {
-      "type": "event_handler",
-      "output": {},
-      "parent": "slot_9_1585096776672",
-      "context": {
-        "location": "@sys-location"
-      },
-      "conditions": "@sys-location",
-      "event_name": "input",
-      "dialog_node": "handler_2_1585096776761"
-    },
-    {
-      "type": "standard",
-      "title": "How Many Cases",
-      "parent": "node_4_1585096044203",
-      "actions": [
-        {
-          "name": "main_webhook",
-          "type": "webhook",
-          "parameters": {
-            "type": "api"
-          },
-          "result_variable": "summary"
-        }
-      ],
-      "metadata": {
-        "_customization": {
-          "mcr": true
-        }
-      },
-      "conditions": "#How_many_cases",
-      "dialog_node": "node_3_1585093908809"
-    },
-    {
-      "type": "standard",
-      "title": "node_11790",
-      "output": {},
-      "parent": "node_11788",
-      "context": {},
-      "next_step": {
-        "behavior": "jump_to",
-        "selector": "body",
-        "dialog_node": "node_11749"
-      },
-      "conditions": "anything_else",
-      "dialog_node": "node_11790",
-      "previous_sibling": "node_11789"
-    },
-    {
-      "type": "standard",
-      "title": "node_11789",
-      "output": {},
-      "parent": "node_11788",
-      "context": {},
-      "next_step": {
-        "behavior": "jump_to",
-        "selector": "body",
-        "dialog_node": "node_11748"
-      },
-      "conditions": "input.text == '' && !input.button",
-      "dialog_node": "node_11789"
-    },
-    {
-      "type": "slot",
-      "parent": "node_4_1585096079466",
-      "variable": "$location",
-      "dialog_node": "slot_9_1585096776672",
-      "previous_sibling": "response_3_1585096899249"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "text": {
-          "values": [
-            "I could not find any information on that."
-          ],
-          "selection_policy": "sequential"
-        }
-      },
-      "parent": "node_4_1585096079466",
-      "conditions": "anything_else",
-      "dialog_node": "response_3_1585096899249",
-      "previous_sibling": "response_9_1585096897994"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "generic": [
-          {
-            "values": [
-              {
-                "text": "Here are the stats for <?$location?> "
-              }
-            ],
-            "response_type": "text",
-            "selection_policy": "sequential"
-          },
-          {
-            "values": [
-              {
-                "text": "$location_stats.result"
-              }
-            ],
-            "response_type": "text",
-            "selection_policy": "sequential"
-          }
-        ]
-      },
-      "parent": "node_4_1585096079466",
-      "conditions": "$location_stats",
-      "dialog_node": "response_9_1585096897994"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "text": {
-          "values": [
-            "Try again later."
-          ],
-          "selection_policy": "sequential"
-        }
-      },
-      "parent": "node_2_1584976214871",
-      "conditions": "anything_else",
-      "dialog_node": "response_2_1584976331717",
-      "previous_sibling": "response_5_1584976331463"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "generic": [
-          {
-            "values": [
-              {
-                "text": "$webhook_result_1.result"
-              }
-            ],
-            "response_type": "text",
-            "selection_policy": "sequential"
-          }
-        ]
-      },
-      "parent": "node_2_1584976214871",
-      "conditions": "$webhook_result_1",
-      "dialog_node": "response_5_1584976331463"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "text": {
-          "values": [
-            "I could not find any thing "
-          ],
-          "selection_policy": "sequential"
-        }
-      },
-      "parent": "node_3_1585093908809",
-      "conditions": "anything_else",
-      "dialog_node": "response_7_1585095664425",
-      "previous_sibling": "response_1_1585095663277"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "generic": [
-          {
-            "values": [
-              {
-                "text": "This is all the confirmed cases I have found"
-              }
-            ],
-            "response_type": "text",
-            "selection_policy": "sequential"
-          },
-          {
-            "values": [
-              {
-                "text": "$summary.result"
-              }
-            ],
-            "response_type": "text",
-            "selection_policy": "sequential"
-          },
-          {
-            "values": [
-              {
-                "text": "Would you like the stats of a specific country?"
-              }
-            ],
-            "response_type": "text",
-            "selection_policy": "sequential"
-          }
-        ]
-      },
-      "parent": "node_3_1585093908809",
-      "conditions": "$summary",
-      "dialog_node": "response_1_1585095663277",
-      "previous_sibling": "node_4_1585096079466"
-    },
-    {
-      "type": "frame",
-      "title": "Country Info",
-      "parent": "node_3_1585093908809",
-      "actions": [
-        {
-          "name": "main_webhook",
-          "type": "webhook",
-          "parameters": {
-            "type": "api",
-            "country": "$location"
-          },
-          "result_variable": "location_stats"
-        }
-      ],
-      "metadata": {
-        "_customization": {
-          "mcr": true
-        }
-      },
-      "conditions": "@reply:yes",
-      "dialog_node": "node_4_1585096079466",
-      "previous_sibling": "slot_8_1585096407905"
-    },
-    {
-      "type": "slot",
-      "parent": "node_3_1585093908809",
-      "variable": "$location",
-      "dialog_node": "slot_8_1585096407905"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "text": {
-          "values": [
-            "I don't know the answer to that yet. But I am learning new things all the time."
-          ],
-          "selection_policy": "sequential"
-        }
-      },
-      "parent": "node_11749",
-      "conditions": "anything_else",
-      "dialog_node": "response_10_1585074744879",
-      "previous_sibling": "response_10_1585074743918"
-    },
-    {
-      "type": "response_condition",
-      "output": {
-        "text": {
-          "values": [
-            "I don't know the answer to that yet.  $webhook_result_2.result"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "parent": "node_11749",
-      "context": {},
-      "conditions": "$webhook_result_2",
-      "dialog_node": "response_10_1585074743918"
-    },
     {
       "type": "response_condition",
       "output": {
@@ -1795,6 +1517,221 @@
       "dialog_node": "response_3_1585158186121"
     },
     {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "Try again later."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "node_2_1584976214871",
+      "conditions": "anything_else",
+      "dialog_node": "response_2_1584976331717",
+      "previous_sibling": "response_5_1584976331463"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "generic": [
+          {
+            "values": [
+              {
+                "text": "$webhook_result_1.result"
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          }
+        ]
+      },
+      "parent": "node_2_1584976214871",
+      "conditions": "$webhook_result_1",
+      "dialog_node": "response_5_1584976331463"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "I could not find any information on that."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "node_4_1585096079466",
+      "conditions": "anything_else",
+      "dialog_node": "response_3_1585096899249",
+      "previous_sibling": "response_9_1585096897994"
+    },
+    {
+      "type": "slot",
+      "parent": "node_4_1585096079466",
+      "variable": "$location",
+      "dialog_node": "slot_9_1585096776672",
+      "previous_sibling": "response_3_1585096899249"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "generic": [
+          {
+            "values": [
+              {
+                "text": "Here are the stats for <?$location?> "
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          },
+          {
+            "values": [
+              {
+                "text": "$location_stats.result"
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          }
+        ]
+      },
+      "parent": "node_4_1585096079466",
+      "conditions": "$location_stats",
+      "dialog_node": "response_9_1585096897994"
+    },
+    {
+      "type": "standard",
+      "title": "How Many Cases",
+      "parent": "node_4_1585096044203",
+      "actions": [
+        {
+          "name": "main_webhook",
+          "type": "webhook",
+          "parameters": {
+            "type": "api"
+          },
+          "result_variable": "summary"
+        }
+      ],
+      "metadata": {
+        "_customization": {
+          "mcr": true
+        }
+      },
+      "conditions": "#How_many_cases",
+      "dialog_node": "node_3_1585093908809"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "generic": [
+          {
+            "values": [
+              {
+                "text": "This is all the confirmed cases I have found"
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          },
+          {
+            "values": [
+              {
+                "text": "$summary.result"
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          },
+          {
+            "values": [
+              {
+                "text": "Would you like the stats of a specific country?"
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          }
+        ]
+      },
+      "parent": "node_3_1585093908809",
+      "conditions": "$summary",
+      "dialog_node": "response_1_1585095663277",
+      "previous_sibling": "node_4_1585096079466"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "I could not find any thing "
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "node_3_1585093908809",
+      "conditions": "anything_else",
+      "dialog_node": "response_7_1585095664425",
+      "previous_sibling": "response_1_1585095663277"
+    },
+    {
+      "type": "frame",
+      "title": "Country Info",
+      "parent": "node_3_1585093908809",
+      "actions": [
+        {
+          "name": "main_webhook",
+          "type": "webhook",
+          "parameters": {
+            "type": "api",
+            "country": "$location"
+          },
+          "result_variable": "location_stats"
+        }
+      ],
+      "metadata": {
+        "_customization": {
+          "mcr": true
+        }
+      },
+      "conditions": "@reply:yes",
+      "dialog_node": "node_4_1585096079466",
+      "previous_sibling": "slot_8_1585096407905"
+    },
+    {
+      "type": "slot",
+      "parent": "node_3_1585093908809",
+      "variable": "$location",
+      "dialog_node": "slot_8_1585096407905"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": [
+            "What country would you like the stats for?"
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "slot_9_1585096776672",
+      "event_name": "focus",
+      "dialog_node": "handler_10_1585096776761",
+      "previous_sibling": "handler_2_1585096776761"
+    },
+    {
+      "type": "event_handler",
+      "output": {},
+      "parent": "slot_9_1585096776672",
+      "context": {
+        "location": "@sys-location"
+      },
+      "conditions": "@sys-location",
+      "event_name": "input",
+      "dialog_node": "handler_2_1585096776761"
+    },
+    {
       "type": "event_handler",
       "output": {
         "text": {
@@ -1821,14 +1758,26 @@
       "dialog_node": "handler_3_1585096407991"
     },
     {
-      "type": "standard",
-      "title": "Goodbye",
+      "type": "response_condition",
       "output": {
         "text": {
           "values": [
-            "Farewell!",
-            "Take Care",
-            "Stay Safe Out There"
+            "I don't know the answer to that yet. But I am learning new things all the time."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "node_11749",
+      "conditions": "anything_else",
+      "dialog_node": "response_10_1585074744879",
+      "previous_sibling": "response_10_1585074743918"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "I don't know the answer to that yet.  $webhook_result_2.result"
           ],
           "selection_policy": "sequential"
         },
@@ -1837,18 +1786,18 @@
           "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
         ]
       },
+      "parent": "node_11749",
       "context": {},
-      "conditions": "#goodbyes && intents[0].confidence > 0.95",
-      "dialog_node": "node_11791",
-      "previous_sibling": "node_11748"
+      "conditions": "$webhook_result_2",
+      "dialog_node": "response_10_1585074743918"
     },
     {
       "type": "standard",
-      "title": "Student and School Meals",
+      "title": "Protecting Children from COVID",
       "output": {
         "text": {
           "values": [
-            "Check with your school on plans to continue meal services during the school dismissal. Many schools are keeping school facilities open to allow families to pick up meals or are providing grab-and-go meals at a central location."
+            "You can encourage your child to help stop the spread of COVID-19 by teaching them to do the same things everyone should do to stay healthy. Clean hands often using soap and water or alcohol-based hand sanitizer Avoid people who are sick (coughing and sneezing) Clean and disinfect high-touch surfaces daily in household common areas (e.g. tables, hard-backed chairs, doorknobs, light switches, remotes, handles, desks, toilets, sinks) Launder items including washable plush toys as appropriate in accordance with the manufacturer’s instructions. If possible, launder items using the warmest appropriate water setting for the items and dry items completely. Dirty laundry from an ill person can be washed with other people’s items. You can find additional information on preventing COVID-19 at Prevention for 2019 Novel Coronavirus and at Preventing COVID-19 Spread in Communities . Additional information on how COVID-19 is spread by asking How does the coronavirus Spread"
           ],
           "selection_policy": "sequential"
         },
@@ -1858,17 +1807,17 @@
         ]
       },
       "context": {},
-      "conditions": "(#MealsForStudents && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11787",
-      "previous_sibling": "node_11786"
+      "conditions": "(#ProtectingChildren && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11765",
+      "previous_sibling": "node_11764"
     },
     {
       "type": "standard",
-      "title": "Risk to Pets",
+      "title": "Higher Risk Populations",
       "output": {
         "text": {
           "values": [
-            "While this virus seems to have emerged from an animal source, it is now spreading from person-to-person. There is no reason to think that any animals including pets in the United States might be a source of infection with this new coronavirus. To date, CDC has not received any reports of pets or other animals becoming sick with COVID-19. At this time, there is no evidence that companion animals including pets can spread COVID-19. However, since animals can spread other diseases to people, it’s always a good idea to wash your hands after being around animals. For more information on the many benefits of pet ownership, as well as staying safe and healthy around animals including pets, livestock, and wildlife, visit CDC’s Healthy Pets, Healthy People website"
+            "Older adults and people of any age who have serious underlying medical conditions may be at higher risk for more serious complications from COVID-19. Based upon available information to date, those most at risk include People 65 years and older, People who live in a nursing home or long-term care facility, People of any age with the following underlying medical conditions, particularly those that are not well controlled, Chronic lung disease or asthma, Congestive heart failure or coronary artery disease, Diabetes, Neurologic conditions that weaken ability to cough, Weakened immune system, Chemotherapy or radiation for cancer (currently or in recent past), Sickle cell anemia, Chronic kidney disease requiring dialysis, Cirrhosis of the liver, Lack of spleen or a spleen that doesn’t function correctly, Extreme obesity (body mass index [BMI] > 40), People who are pregnant."
           ],
           "selection_policy": "sequential"
         },
@@ -1878,129 +1827,9 @@
         ]
       },
       "context": {},
-      "conditions": "(#RiskToPets && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11783",
-      "previous_sibling": "node_11782"
-    },
-    {
-      "type": "standard",
-      "title": "Preparing and Calming Children",
-      "output": {
-        "text": {
-          "values": [
-            "Outbreaks can be stressful for adults and children. Talk with your children about the outbreak, try to stay calm, and reassure them that they are safe. If appropriate, explain to them that most illness from COVID-19 seems to be mild. Children respond differently to stressful situations than adults."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#PreparingChildren && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11773",
-      "previous_sibling": "node_11772"
-    },
-    {
-      "type": "standard",
-      "title": "Naming of Virus",
-      "output": {
-        "text": {
-          "values": [
-            "On February 11, 2020 the World Health Organization announced an official name for the disease that is causing the 2019 novel coronavirus outbreak, first identified in Wuhan China. The new name of this disease is coronavirus disease 2019, abbreviated as COVID-19. In COVID-19, ‘CO’ stands for ‘corona,’ ‘VI’ for ‘virus,’ and ‘D’ for disease. Formerly, this disease was referred to as “2019 novel coronavirus” or “2019-nCoV”. There are many types of human coronaviruses including some that commonly cause mild upper-respiratory tract illnesses. COVID-19 is a new disease, caused be a novel (or new) coronavirus that has not previously been seen in humans. The name of this disease was selected following the World Health Organization (WHO) best practice for naming of new human infectious diseases."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Whythename && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11752",
-      "previous_sibling": "node_11751"
-    },
-    {
-      "type": "standard",
-      "title": "Disinfecting Surfaces",
-      "output": {
-        "text": {
-          "values": [
-            "Clean and disinfect frequently touched surfaces such as tables, doorknobs, light switches, countertops, handles, desks, phones, keyboards, toilets, faucets, and sinks. If surfaces are dirty, clean them using detergent or soap and water prior to disinfection. To disinfect, most common EPA-registered household disinfectants will work. See CDC’s recommendations for household cleaning and disinfection In Case of an Outbreak in Your Community"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#DisinfectingSurfaces && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11772",
-      "previous_sibling": "node_11771"
-    },
-    {
-      "type": "standard",
-      "title": "Children and Face Masks",
-      "output": {
-        "text": {
-          "values": [
-            "If your child is healthy, there is no need for them to wear a facemask. Only people who have symptoms of illness or who are providing care to those who are ill should wear masks."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#ChildrenAndFaceMasks && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11767",
-      "previous_sibling": "node_11766"
-    },
-    {
-      "type": "standard",
-      "title": "How does it Spread",
-      "output": {
-        "text": {
-          "values": [
-            "This virus was first detected in Wuhan City, Hubei Province, China. The first infections were linked to a live animal market, but the virus is now spreading from person-to-person. It’s important to note that person-to-person spread can happen on a continuum. Some viruses are highly contagious (like measles), while other viruses are less so. The virus that causes COVID-19 seems to be spreading easily and sustainably in the community (“community spread”) in some affected geographic areas. Community spread means people have been infected with the virus in an area, including some who are not sure how or where they became infected."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#HowDoesItSpread && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11753",
-      "previous_sibling": "node_11752"
-    },
-    {
-      "type": "standard",
-      "title": "Products and Packages from China",
-      "output": {
-        "text": {
-          "values": [
-            "There is still a lot that is unknown about the newly emerged COVID-19 and how it spreads. Two other coronaviruses have emerged previously to cause severe illness in people (MERS-CoV and SARS-CoV). The virus that causes COVID-19 is more genetically related to SARS-CoV than MERS-CoV, but both are betacoronaviruses with their origins in bats. While we don’t know for sure that this virus will behave the same way as SARS-CoV and MERS-CoV, we can use the information gained from both of these earlier coronaviruses to guide us. In general, because of poor survivability of these coronaviruses on surfaces, there is likely very low risk of spread from products or packaging that are shipped over a period of days or weeks at ambient temperatures. Coronaviruses are generally thought to be spread most often by respiratory droplets. Currently there is no evidence to support transmission of COVID-19 associated with imported goods and there have not been any cases of COVID-19 in the United States associated with imported goods. Information will be provided on the Coronavirus Disease 2019 (COVID-19) website as it becomes available."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#ProductsFromChina && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11763",
-      "previous_sibling": "node_11762"
+      "conditions": "(#HigherRiskPopulations && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11761",
+      "previous_sibling": "node_11760"
     },
     {
       "type": "standard",
@@ -2047,316 +1876,6 @@
     },
     {
       "type": "standard",
-      "title": "Reduce Family Risk",
-      "output": {
-        "text": {
-          "values": [
-            "Practice everyday preventive actions to help reduce your risk of getting sick and remind everyone in your home to do the same. These actions are especially important for older adults and people who have severe chronic medical conditions: Avoid close contact with people who are sick. Cover your coughs and sneezes with a tissue and throw the tissue in the trash. Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food. If soap and water are not readily available, use an alcohol-based hand sanitizer with at least 60% alcohol. Always wash hands with soap and water if hands are visibly dirty. Clean and disinfect frequently touched surfaces and objects (e.g., tables, countertops, light switches, doorknobs, and cabinet handles)."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#ReduceFamilyRisk && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11769",
-      "previous_sibling": "node_11768"
-    },
-    {
-      "type": "standard",
-      "title": "Latest News on Covid19",
-      "actions": [
-        {
-          "name": "main_webhook",
-          "type": "webhook",
-          "parameters": {
-            "": ""
-          },
-          "result_variable": "webhook_result_1"
-        }
-      ],
-      "metadata": {
-        "_customization": {
-          "mcr": true
-        }
-      },
-      "conditions": "#News_Corona_Virus",
-      "dialog_node": "node_2_1584976214871",
-      "previous_sibling": "node_4_1585096044203"
-    },
-    {
-      "type": "folder",
-      "title": "api",
-      "dialog_node": "node_4_1585096044203",
-      "previous_sibling": "node_11791"
-    },
-    {
-      "type": "standard",
-      "title": "Info about Stigmatized Groups",
-      "output": {
-        "text": {
-          "values": [
-            "People in the U.S. may be worried or anxious about friends and relatives who are living in or visiting areas where COVID-19 is spreading. Some people are worried about the disease. Fear and anxiety can lead to social stigma, for example, towards Chinese or other Asian Americans or people who were in quarantine. Stigma is discrimination against an identifiable group of people, a place, or a nation. Stigma is associated with a lack of knowledge about how COVID-19 spreads, a need to blame someone, fears about disease and death, and gossip that spreads rumors and myths. Stigma hurts everyone by creating more fear or anger towards ordinary people instead of the disease that is causing the problem."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Stigmatizedgroups && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11779",
-      "previous_sibling": "node_11778"
-    },
-    {
-      "type": "standard",
-      "title": "Health Dept Recommended Actions",
-      "output": {
-        "text": {
-          "values": [
-            "For recommendations and guidance on persons under investigation; infection control, including personal protective equipment guidance; home care and isolation; and case investigation, see Information for Healthcare Professionals . For information on specimen collection and shipment, see Information for Laboratories. For information for public health professional on COVID-19, see Information for Public Health Professionals See also: FAQs for Healthcare Professionals COVID-19 and Funerals"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#HealthDeptRecommendedActions && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11780",
-      "previous_sibling": "node_11779"
-    },
-    {
-      "type": "standard",
-      "title": "Symptoms of COVID19",
-      "output": {
-        "text": {
-          "values": [
-            "Current symptoms reported for patients with COVID-19 have included mild to severe respiratory illness with fever , cough, and difficulty breathing. Read about COVID-19 Symptoms"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Symptoms && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11776",
-      "previous_sibling": "node_11775"
-    },
-    {
-      "type": "standard",
-      "title": "Greetings",
-      "output": {
-        "text": {
-          "values": [
-            "Hello, I’m the COVID Crisis Communication Bot ready to answer your questions about COVID-19. How can I help you?"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "#greeting && intents[0].confidence > 0.95",
-      "dialog_node": "node_11748",
-      "previous_sibling": "node_11788"
-    },
-    {
-      "type": "standard",
-      "title": "Can it spread via food?",
-      "output": {
-        "text": {
-          "values": [
-            "Coronaviruses are generally thought to be spread from person-to-person through respiratory droplets. Currently there is no evidence to support transmission of COVID-19 associated with food. Before preparing or eating food it is important to always wash your hands with soap and water for 20 seconds for general food safety. Throughout the day wash your hands after blowing your nose, coughing or sneezing, or going to the bathroom. In general, because of poor survivability of these coronaviruses on surfaces, there is likely very low risk of spread from food products or packaging that are shipped over a period of days or weeks at ambient, refrigerated, or frozen temperatures."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#spreadviafood && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11757",
-      "previous_sibling": "node_11756"
-    },
-    {
-      "type": "standard",
-      "title": "Should I wear face masks?",
-      "output": {
-        "text": {
-          "values": [
-            "CDC does not recommend that people who are well wear a facemask to protect themselves from respiratory illnesses, including COVID-19. You should only wear a mask if a healthcare professional recommends it. A facemask should be used by people who have COVID-19 and are showing symptoms. This is to protect others from the risk of getting infected. The use of facemasks also is crucial for health workers and other people who are taking care of someone infected with COVID-19 in close settings (at home or in a health care facility)."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Wearingfacemasks && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11762",
-      "previous_sibling": "node_11761"
-    },
-    {
-      "type": "standard",
-      "title": "Family Preparation",
-      "output": {
-        "text": {
-          "values": [
-            "Create a household plan of action to help protect your health and the health of those you care about in the event of an outbreak of COVID-19 in your community: Talk with the people who need to be included in your plan, and discuss what to do if a COVID-19 outbreak occurs in your community Plan ways to care for those who might be at greater risk for serious complications, particularly older adults and those with severe chronic medical conditions like heart, lung or kidney disease. Make sure they have access to several weeks of medications and supplies in case you need to stay home for prolonged periods of time. Get to know your neighbors and find out if your neighborhood has a website or social media page to stay connected. Create a list of local organizations that you and your household can contact in the event you need access to information, healthcare services, support, and resources. Create an emergency contact list of family, friends, neighbors, carpool drivers, health care providers, teachers, employers, the local public health department, and other community resources."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#PrepareFamily && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11768",
-      "previous_sibling": "node_11767"
-    },
-    {
-      "type": "standard",
-      "title": "School Closing Information",
-      "output": {
-        "text": {
-          "values": [
-            "Depending on the situation, public health officials may recommend community actions to reduce exposures to COVID-19, such as school dismissals. Read or watch local media sources that report school dismissals or and watch for communication from your child’s school. If schools are dismissed temporarily, discourage students and staff from gathering or socializing anywhere, like at a friend’s house, a favorite restaurant, or the local shopping mall."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#schoolclosing && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11774",
-      "previous_sibling": "node_11773"
-    },
-    {
-      "type": "standard",
-      "title": "node_11749",
-      "actions": [
-        {
-          "name": "main_webhook",
-          "type": "webhook",
-          "parameters": {
-            "input": "<?input.text?>"
-          },
-          "result_variable": "webhook_result_2"
-        }
-      ],
-      "metadata": {
-        "_customization": {
-          "mcr": true
-        }
-      },
-      "conditions": "anything_else",
-      "dialog_node": "node_11749",
-      "previous_sibling": "node_11750"
-    },
-    {
-      "type": "standard",
-      "title": "Warmer Weather Mitigation",
-      "output": {
-        "text": {
-          "values": [
-            "It is not yet known whether weather and temperature impact the spread of COVID-19. Some other viruses, like the common cold and flu, spread more during cold weather months but that does not mean it is impossible to become sick with these viruses during other months. At this time, it is not known whether the spread of COVID-19 will decrease when weather becomes warmer. There is much more to learn about the transmissibility, severity, and other features associated with COVID-19 and investigations are ongoing."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#warmerweather && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11758",
-      "previous_sibling": "node_11757"
-    },
-    {
-      "type": "standard",
-      "title": "Guidance on going in to work",
-      "output": {
-        "text": {
-          "values": [
-            "Follow the advice of your local health officials. Stay home if you can. Talk to your employer to discuss working from home, taking leave if you or someone in your household gets sick with COVID-19 symptoms , or if your child’s school is dismissed temporarily. Employers should be aware that more employees may need to stay at home to care for sick children or other sick family members than is usual in case of a community outbreak."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#ReportingToWork && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11775",
-      "previous_sibling": "node_11774"
-    },
-    {
-      "type": "standard",
-      "title": "Handwashing tips and Guidance",
-      "output": {
-        "text": {
-          "values": [
-            "Handwashing is one of the best ways to protect yourself and your family from getting sick. Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food. If soap and water are not readily available, use an alcohol-based hand sanitizer with at least 60% alcohol."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#HandwashingTips && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11771",
-      "previous_sibling": "node_11770"
-    },
-    {
-      "type": "standard",
-      "title": "Child socialization",
-      "output": {
-        "text": {
-          "values": [
-            "The key to slowing the spread of COVID-19 is to limit social interactions as much as possible. Parents should minimize play dates, and if held, parents should keep the groups small. Advise older children to hang out in a small group and to meet up outside rather than inside. It’s easier to keep and maintain space between others in outdoor settings, like parks. If you have small meetups, consider hanging out with another family or friend who is also taking extra measures to put distance between themselves and others (i.e. social distancing). Make sure children practice everyday preventive behaviors , such as cleaning and then disinfecting frequently touched surfaces. Remember, if children meet outside of school in bigger groups, it can put everyone at risk. This includes spring break and other group travel. Parents should help their older children revise spring break plans that included non-essential travel to crowded areas. Information about COVID-19 in children is somewhat limited, but current data suggest children with COVID-19 may show only mild symptoms. However, they can still pass this virus onto others who may be at higher risk, including older adults and people who have serious chronic medical conditions"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#ChildrenSocializing && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11785",
-      "previous_sibling": "node_11784"
-    },
-    {
-      "type": "standard",
       "title": "What is Covid19?",
       "output": {
         "text": {
@@ -2374,246 +1893,6 @@
       "conditions": "(#WhatisCovid && intents[0].confidence > $low_confidence)",
       "dialog_node": "node_11751",
       "previous_sibling": "node_2_1584976214871"
-    },
-    {
-      "type": "standard",
-      "title": "Protecting Children from COVID",
-      "output": {
-        "text": {
-          "values": [
-            "You can encourage your child to help stop the spread of COVID-19 by teaching them to do the same things everyone should do to stay healthy. Clean hands often using soap and water or alcohol-based hand sanitizer Avoid people who are sick (coughing and sneezing) Clean and disinfect high-touch surfaces daily in household common areas (e.g. tables, hard-backed chairs, doorknobs, light switches, remotes, handles, desks, toilets, sinks) Launder items including washable plush toys as appropriate in accordance with the manufacturer’s instructions. If possible, launder items using the warmest appropriate water setting for the items and dry items completely. Dirty laundry from an ill person can be washed with other people’s items. You can find additional information on preventing COVID-19 at Prevention for 2019 Novel Coronavirus and at Preventing COVID-19 Spread in Communities . Additional information on how COVID-19 is spread by asking How does the coronavirus Spread"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#ProtectingChildren && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11765",
-      "previous_sibling": "node_11764"
-    },
-    {
-      "type": "standard",
-      "title": "Testing Information",
-      "output": {
-        "text": {
-          "values": [
-            "If you develop symptoms such as fever, cough, and/or difficulty breathing, and have been in close contact with a person known to have COVID-19 or have recently traveled from an area with ongoing spread of COVID-19 , stay home and call your healthcare provider. Older patients and individuals who have severe underlying medical conditions or are immunocompromised should contact their healthcare provider early, even if their illness is mild. If you have severe symptoms, such as persistent pain or pressure in the chest, new confusion or inability to arouse, or bluish lips of face, contact your healthcare provider or emergency room and seek care immediately. Your doctor will determine if you have signs and symptoms of COVID-19 and whether you should be tested."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Testing && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11777",
-      "previous_sibling": "node_11776"
-    },
-    {
-      "type": "standard",
-      "title": "What symptoms are shown in Children?",
-      "output": {
-        "text": {
-          "values": [
-            "The symptoms of COVID-19 are similar in children and adults. However, children with confirmed COVID-19 have generally presented with mild symptoms. Reported symptoms in children include cold-like symptoms, such as fever, runny nose, and cough. Vomiting and diarrhea have also been reported. It’s not known yet whether some children may be at higher risk for severe illness, for example, children with underlying medical conditions and special healthcare needs. There is much more to be learned about how the disease impacts children."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Symptomsinchildren && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11766",
-      "previous_sibling": "node_11765"
-    },
-    {
-      "type": "standard",
-      "title": "What is Quarantine",
-      "output": {
-        "text": {
-          "values": [
-            "Quarantine means separating a person or group of people who have been exposed to a contagious disease but have not developed illness (symptoms) from others who have not been exposed, in order to prevent the possible spread of that disease. Quarantine is usually established for the incubation period of the communicable disease, which is the span of time during which people have developed illness after exposure. For COVID-19, the period of quarantine is 14 days from the last date of exposure, because 14 days is the longest incubation period seen for similar coronaviruses. Someone who has been released from COVID-19 quarantine is not considered a risk for spreading the virus to others because they have not developed illness during the incubation period."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#spreadinquarantine && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11756",
-      "previous_sibling": "node_11755"
-    },
-    {
-      "type": "standard",
-      "title": "Person to Person Spread",
-      "output": {
-        "text": {
-          "values": [
-            "The virus that causes COVID-19 is spreading from person-to-person . Someone who is actively sick with COVID-19 can spread the illness to others. That is why CDC recommends that these patients be isolated either in the hospital or at home (depending on how sick they are) until they are better and no longer pose a risk of infecting others. How long someone is actively sick can vary so the decision on when to release someone from isolation is made on a case-by-case basis in consultation with doctors, infection prevention and control experts, and public health officials and involves considering specifics of each situation including disease severity, illness signs and symptoms, and results of laboratory testing for that patient. Current CDC guidance for when it is OK to release someone from isolation is made on a case by case basis and includes meeting all of the following requirements: The patient is free from fever without the use of fever-reducing medications. The patient is no longer showing symptoms, including cough. The patient has tested negative on at least two consecutive respiratory specimens collected at least 24 hours apart. Someone who has been released from isolation is not considered to pose a risk of infection to others."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#PersonToPerson && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11755",
-      "previous_sibling": "node_11754"
-    },
-    {
-      "type": "standard",
-      "title": "Higher Risk Populations",
-      "output": {
-        "text": {
-          "values": [
-            "Older adults and people of any age who have serious underlying medical conditions may be at higher risk for more serious complications from COVID-19. Based upon available information to date, those most at risk include People 65 years and older, People who live in a nursing home or long-term care facility, People of any age with the following underlying medical conditions, particularly those that are not well controlled, Chronic lung disease or asthma, Congestive heart failure or coronary artery disease, Diabetes, Neurologic conditions that weaken ability to cough, Weakened immune system, Chemotherapy or radiation for cancer (currently or in recent past), Sickle cell anemia, Chronic kidney disease requiring dialysis, Cirrhosis of the liver, Lack of spleen or a spleen that doesn’t function correctly, Extreme obesity (body mass index [BMI] > 40), People who are pregnant."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#HigherRiskPopulations && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11761",
-      "previous_sibling": "node_11760"
-    },
-    {
-      "type": "standard",
-      "title": "CDC Guidance and Response",
-      "output": {
-        "text": {
-          "values": [
-            "This is an emerging, rapidly evolving situation and CDC will continue to provide updated information as it becomes available. CDC works 24/7 to protect people’s health.  For CDC guidance please visit: https://www.cdc.gov/coronavirus/2019-nCoV/index.html"
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#CDC_Response && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11782",
-      "previous_sibling": "node_11781"
-    },
-    {
-      "type": "standard",
-      "title": "Where did it originate?",
-      "output": {
-        "text": {
-          "values": [
-            "Coronaviruses are a large family of viruses. Some cause illness in people, and others, such as canine and feline coronaviruses, only infect animals. Rarely, animal coronaviruses that infect animals have emerged to infect people and can spread between people. This is suspected to have occurred for the virus that causes COVID-19. Middle East Respiratory Syndrome (MERS) and Severe Acute Respiratory Syndrome (SARS) are two other examples of coronaviruses that originated from animals and then spread to people."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#Wherediditstart && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11754",
-      "previous_sibling": "node_11753"
-    },
-    {
-      "type": "standard",
-      "title": "Animal Contact",
-      "output": {
-        "text": {
-          "values": [
-            "You should restrict contact with pets and other animals while you are sick with COVID-19, just like you would around other people. Although there have not been reports of pets or other animals becoming sick with COVID-19, it is still recommended that people sick with COVID-19 limit contact with animals until more information is known about the virus. When possible, have another member of your household care for your animals while you are sick. If you are sick with COVID-19, avoid contact with your pet, including petting, snuggling, being kissed or licked, and sharing food. If you must care for your pet or be around animals while you are sick, wash your hands before and after you interact with pets and wear a facemask."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#AnimalContact && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11784",
-      "previous_sibling": "node_11783"
-    },
-    {
-      "type": "standard",
-      "title": "Can I attend funerals?",
-      "output": {
-        "text": {
-          "values": [
-            "There is currently no known risk associated with being in the same room at a funeral or visitation service with the body of someone who died of COVID-19."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#AttendingFuneral && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11781",
-      "previous_sibling": "node_11780"
-    },
-    {
-      "type": "standard",
-      "title": "Community Spread",
-      "output": {
-        "text": {
-          "values": [
-            "Community spread means people have been infected with the virus in an area, including some who are not sure how or where they became infected."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#CommunitySpread && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11759",
-      "previous_sibling": "node_11758"
-    },
-    {
-      "type": "standard",
-      "title": "Infected Family Member",
-      "output": {
-        "text": {
-          "values": [
-            "Most people who get COVID-19 will be able to recover at home. CDC has directions for people who are recovering at home and their caregivers, including: Stay home when you are sick, except to get medical care. If you develop emergency warning signs for COVID-19 get medical attention immediately . Emergency warning signs include*: Trouble breathing Persistent pain or pressure in the chest New confusion or inability to arouse Bluish lips or face *This list is not all inclusive. Please consult your medical provider for any other symptoms that are severe or concerning. Use a separate room and bathroom for sick household members (if possible). Clean hands regularly by handwashing with soap and water or using an alcohol-based hand sanitizer with at least 60% alcohol. Provide your sick household member with clean disposable facemasks to wear at home, if available, to help prevent spreading COVID-19 to others. Clean the sick room and bathroom , as needed, to avoid unnecessary contact with the sick person. Avoid sharing personal items like utensils, food, and drinks."
-          ],
-          "selection_policy": "sequential"
-        },
-        "video": {},
-        "disclaimers": [
-          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
-        ]
-      },
-      "context": {},
-      "conditions": "(#InfectedFamilyMember && intents[0].confidence > $low_confidence)",
-      "dialog_node": "node_11770",
-      "previous_sibling": "node_11769"
     },
     {
       "type": "standard",
@@ -2657,36 +1936,675 @@
     },
     {
       "type": "standard",
-      "title": "node_11750",
+      "title": "Family Preparation",
       "output": {
         "text": {
           "values": [
-            "Did you mean:",
-            "You seem to be asking about: ",
-            "I think you were asking about:"
+            "Create a household plan of action to help protect your health and the health of those you care about in the event of an outbreak of COVID-19 in your community: Talk with the people who need to be included in your plan, and discuss what to do if a COVID-19 outbreak occurs in your community Plan ways to care for those who might be at greater risk for serious complications, particularly older adults and those with severe chronic medical conditions like heart, lung or kidney disease. Make sure they have access to several weeks of medications and supplies in case you need to stay home for prolonged periods of time. Get to know your neighbors and find out if your neighborhood has a website or social media page to stay connected. Create a list of local organizations that you and your household can contact in the event you need access to information, healthcare services, support, and resources. Create an emergency contact list of family, friends, neighbors, carpool drivers, health care providers, teachers, employers, the local public health department, and other community resources."
           ],
           "selection_policy": "sequential"
         },
         "video": {},
-        "buttons": [
-          {
-            "id": "<? intents.?[intent != 'greeting' && intent != 'goodbyes'  && intent != 'nonsense' && intent != 'no' && intent != 'yes' && intent != 'weather'][0].intent ?>"
-          },
-          {
-            "id": "<? intents.?[intent != 'greeting' && intent != 'goodbyes'  && intent != 'nonsense' && intent != 'no' && intent != 'yes' && intent != 'weather'][1].intent ?>"
-          },
-          {
-            "id": "<? intents.?[intent != 'greeting' && intent != 'goodbyes'  && intent != 'nonsense' && intent != 'no' && intent != 'yes' && intent != 'weather'][2].intent ?>"
-          }
-        ],
         "disclaimers": [
           "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
         ]
       },
       "context": {},
-      "conditions": "intents.size() > 0 && (intents[0].confidence < $low_confidence && intents[0].confidence > $out_of_bounds)",
-      "dialog_node": "node_11750",
+      "conditions": "(#PrepareFamily && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11768",
+      "previous_sibling": "node_11767"
+    },
+    {
+      "type": "standard",
+      "title": "What symptoms are shown in Children?",
+      "output": {
+        "text": {
+          "values": [
+            "The symptoms of COVID-19 are similar in children and adults. However, children with confirmed COVID-19 have generally presented with mild symptoms. Reported symptoms in children include cold-like symptoms, such as fever, runny nose, and cough. Vomiting and diarrhea have also been reported. It’s not known yet whether some children may be at higher risk for severe illness, for example, children with underlying medical conditions and special healthcare needs. There is much more to be learned about how the disease impacts children."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Symptomsinchildren && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11766",
+      "previous_sibling": "node_11765"
+    },
+    {
+      "type": "standard",
+      "title": "Child socialization",
+      "output": {
+        "text": {
+          "values": [
+            "The key to slowing the spread of COVID-19 is to limit social interactions as much as possible. Parents should minimize play dates, and if held, parents should keep the groups small. Advise older children to hang out in a small group and to meet up outside rather than inside. It’s easier to keep and maintain space between others in outdoor settings, like parks. If you have small meetups, consider hanging out with another family or friend who is also taking extra measures to put distance between themselves and others (i.e. social distancing). Make sure children practice everyday preventive behaviors , such as cleaning and then disinfecting frequently touched surfaces. Remember, if children meet outside of school in bigger groups, it can put everyone at risk. This includes spring break and other group travel. Parents should help their older children revise spring break plans that included non-essential travel to crowded areas. Information about COVID-19 in children is somewhat limited, but current data suggest children with COVID-19 may show only mild symptoms. However, they can still pass this virus onto others who may be at higher risk, including older adults and people who have serious chronic medical conditions"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#ChildrenSocializing && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11785",
+      "previous_sibling": "node_11784"
+    },
+    {
+      "type": "standard",
+      "title": "Latest News on Covid19",
+      "actions": [
+        {
+          "name": "main_webhook",
+          "type": "webhook",
+          "parameters": {
+            "": ""
+          },
+          "result_variable": "webhook_result_1"
+        }
+      ],
+      "metadata": {
+        "_customization": {
+          "mcr": true
+        }
+      },
+      "conditions": "#News_Corona_Virus",
+      "dialog_node": "node_2_1584976214871",
+      "previous_sibling": "node_4_1585096044203"
+    },
+    {
+      "type": "standard",
+      "title": "Anything else",
+      "actions": [
+        {
+          "name": "main_webhook",
+          "type": "webhook",
+          "parameters": {
+            "input": "<?input.text?>"
+          },
+          "result_variable": "webhook_result_2"
+        }
+      ],
+      "metadata": {
+        "_customization": {
+          "mcr": true
+        }
+      },
+      "conditions": "anything_else",
+      "dialog_node": "node_11749",
       "previous_sibling": "node_8_1585238958758"
+    },
+    {
+      "type": "standard",
+      "title": "School Closing Information",
+      "output": {
+        "text": {
+          "values": [
+            "Depending on the situation, public health officials may recommend community actions to reduce exposures to COVID-19, such as school dismissals. Read or watch local media sources that report school dismissals or and watch for communication from your child’s school. If schools are dismissed temporarily, discourage students and staff from gathering or socializing anywhere, like at a friend’s house, a favorite restaurant, or the local shopping mall."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#schoolclosing && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11774",
+      "previous_sibling": "node_11773"
+    },
+    {
+      "type": "standard",
+      "title": "Community Spread",
+      "output": {
+        "text": {
+          "values": [
+            "Community spread means people have been infected with the virus in an area, including some who are not sure how or where they became infected."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#CommunitySpread && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11759",
+      "previous_sibling": "node_11758"
+    },
+    {
+      "type": "standard",
+      "title": "Infected Family Member",
+      "output": {
+        "text": {
+          "values": [
+            "Most people who get COVID-19 will be able to recover at home. CDC has directions for people who are recovering at home and their caregivers, including: Stay home when you are sick, except to get medical care. If you develop emergency warning signs for COVID-19 get medical attention immediately . Emergency warning signs include*: Trouble breathing Persistent pain or pressure in the chest New confusion or inability to arouse Bluish lips or face *This list is not all inclusive. Please consult your medical provider for any other symptoms that are severe or concerning. Use a separate room and bathroom for sick household members (if possible). Clean hands regularly by handwashing with soap and water or using an alcohol-based hand sanitizer with at least 60% alcohol. Provide your sick household member with clean disposable facemasks to wear at home, if available, to help prevent spreading COVID-19 to others. Clean the sick room and bathroom , as needed, to avoid unnecessary contact with the sick person. Avoid sharing personal items like utensils, food, and drinks."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#InfectedFamilyMember && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11770",
+      "previous_sibling": "node_11769"
+    },
+    {
+      "type": "standard",
+      "title": "Animal Contact",
+      "output": {
+        "text": {
+          "values": [
+            "You should restrict contact with pets and other animals while you are sick with COVID-19, just like you would around other people. Although there have not been reports of pets or other animals becoming sick with COVID-19, it is still recommended that people sick with COVID-19 limit contact with animals until more information is known about the virus. When possible, have another member of your household care for your animals while you are sick. If you are sick with COVID-19, avoid contact with your pet, including petting, snuggling, being kissed or licked, and sharing food. If you must care for your pet or be around animals while you are sick, wash your hands before and after you interact with pets and wear a facemask."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#AnimalContact && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11784",
+      "previous_sibling": "node_11783"
+    },
+    {
+      "type": "standard",
+      "title": "Health Dept Recommended Actions",
+      "output": {
+        "text": {
+          "values": [
+            "For recommendations and guidance on persons under investigation; infection control, including personal protective equipment guidance; home care and isolation; and case investigation, see Information for Healthcare Professionals . For information on specimen collection and shipment, see Information for Laboratories. For information for public health professional on COVID-19, see Information for Public Health Professionals See also: FAQs for Healthcare Professionals COVID-19 and Funerals"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#HealthDeptRecommendedActions && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11780",
+      "previous_sibling": "node_11779"
+    },
+    {
+      "type": "standard",
+      "title": "Info about Stigmatized Groups",
+      "output": {
+        "text": {
+          "values": [
+            "People in the U.S. may be worried or anxious about friends and relatives who are living in or visiting areas where COVID-19 is spreading. Some people are worried about the disease. Fear and anxiety can lead to social stigma, for example, towards Chinese or other Asian Americans or people who were in quarantine. Stigma is discrimination against an identifiable group of people, a place, or a nation. Stigma is associated with a lack of knowledge about how COVID-19 spreads, a need to blame someone, fears about disease and death, and gossip that spreads rumors and myths. Stigma hurts everyone by creating more fear or anger towards ordinary people instead of the disease that is causing the problem."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Stigmatizedgroups && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11779",
+      "previous_sibling": "node_11778"
+    },
+    {
+      "type": "standard",
+      "title": "How does it Spread",
+      "output": {
+        "text": {
+          "values": [
+            "This virus was first detected in Wuhan City, Hubei Province, China. The first infections were linked to a live animal market, but the virus is now spreading from person-to-person. It’s important to note that person-to-person spread can happen on a continuum. Some viruses are highly contagious (like measles), while other viruses are less so. The virus that causes COVID-19 seems to be spreading easily and sustainably in the community (“community spread”) in some affected geographic areas. Community spread means people have been infected with the virus in an area, including some who are not sure how or where they became infected."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#HowDoesItSpread && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11753",
+      "previous_sibling": "node_11752"
+    },
+    {
+      "type": "standard",
+      "title": "Should I wear face masks?",
+      "output": {
+        "text": {
+          "values": [
+            "CDC does not recommend that people who are well wear a facemask to protect themselves from respiratory illnesses, including COVID-19. You should only wear a mask if a healthcare professional recommends it. A facemask should be used by people who have COVID-19 and are showing symptoms. This is to protect others from the risk of getting infected. The use of facemasks also is crucial for health workers and other people who are taking care of someone infected with COVID-19 in close settings (at home or in a health care facility)."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Wearingfacemasks && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11762",
+      "previous_sibling": "node_11761"
+    },
+    {
+      "type": "standard",
+      "title": "Preparing and Calming Children",
+      "output": {
+        "text": {
+          "values": [
+            "Outbreaks can be stressful for adults and children. Talk with your children about the outbreak, try to stay calm, and reassure them that they are safe. If appropriate, explain to them that most illness from COVID-19 seems to be mild. Children respond differently to stressful situations than adults."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#PreparingChildren && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11773",
+      "previous_sibling": "node_11772"
+    },
+    {
+      "type": "standard",
+      "title": "Can it spread via food?",
+      "output": {
+        "text": {
+          "values": [
+            "Coronaviruses are generally thought to be spread from person-to-person through respiratory droplets. Currently there is no evidence to support transmission of COVID-19 associated with food. Before preparing or eating food it is important to always wash your hands with soap and water for 20 seconds for general food safety. Throughout the day wash your hands after blowing your nose, coughing or sneezing, or going to the bathroom. In general, because of poor survivability of these coronaviruses on surfaces, there is likely very low risk of spread from food products or packaging that are shipped over a period of days or weeks at ambient, refrigerated, or frozen temperatures."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#spreadviafood && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11757",
+      "previous_sibling": "node_11756"
+    },
+    {
+      "type": "standard",
+      "title": "Student and School Meals",
+      "output": {
+        "text": {
+          "values": [
+            "Check with your school on plans to continue meal services during the school dismissal. Many schools are keeping school facilities open to allow families to pick up meals or are providing grab-and-go meals at a central location."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#MealsForStudents && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11787",
+      "previous_sibling": "node_11786"
+    },
+    {
+      "type": "standard",
+      "title": "Where did it originate?",
+      "output": {
+        "text": {
+          "values": [
+            "Coronaviruses are a large family of viruses. Some cause illness in people, and others, such as canine and feline coronaviruses, only infect animals. Rarely, animal coronaviruses that infect animals have emerged to infect people and can spread between people. This is suspected to have occurred for the virus that causes COVID-19. Middle East Respiratory Syndrome (MERS) and Severe Acute Respiratory Syndrome (SARS) are two other examples of coronaviruses that originated from animals and then spread to people."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Wherediditstart && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11754",
+      "previous_sibling": "node_11753"
+    },
+    {
+      "type": "standard",
+      "title": "Risk to Pets",
+      "output": {
+        "text": {
+          "values": [
+            "While this virus seems to have emerged from an animal source, it is now spreading from person-to-person. There is no reason to think that any animals including pets in the United States might be a source of infection with this new coronavirus. To date, CDC has not received any reports of pets or other animals becoming sick with COVID-19. At this time, there is no evidence that companion animals including pets can spread COVID-19. However, since animals can spread other diseases to people, it’s always a good idea to wash your hands after being around animals. For more information on the many benefits of pet ownership, as well as staying safe and healthy around animals including pets, livestock, and wildlife, visit CDC’s Healthy Pets, Healthy People website"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#RiskToPets && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11783",
+      "previous_sibling": "node_11782"
+    },
+    {
+      "type": "standard",
+      "title": "Goodbye",
+      "output": {
+        "text": {
+          "values": [
+            "Farewell!",
+            "Take Care",
+            "Stay Safe Out There"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "#goodbyes && intents[0].confidence > 0.95",
+      "dialog_node": "node_11791",
+      "previous_sibling": "node_9_1586187460728"
+    },
+    {
+      "type": "standard",
+      "title": "Guidance on going in to work",
+      "output": {
+        "text": {
+          "values": [
+            "Follow the advice of your local health officials. Stay home if you can. Talk to your employer to discuss working from home, taking leave if you or someone in your household gets sick with COVID-19 symptoms , or if your child’s school is dismissed temporarily. Employers should be aware that more employees may need to stay at home to care for sick children or other sick family members than is usual in case of a community outbreak."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#ReportingToWork && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11775",
+      "previous_sibling": "node_11774"
+    },
+    {
+      "type": "folder",
+      "title": "api",
+      "dialog_node": "node_4_1585096044203",
+      "previous_sibling": "node_11791"
+    },
+    {
+      "type": "standard",
+      "title": "Products and Packages from China",
+      "output": {
+        "text": {
+          "values": [
+            "There is still a lot that is unknown about the newly emerged COVID-19 and how it spreads. Two other coronaviruses have emerged previously to cause severe illness in people (MERS-CoV and SARS-CoV). The virus that causes COVID-19 is more genetically related to SARS-CoV than MERS-CoV, but both are betacoronaviruses with their origins in bats. While we don’t know for sure that this virus will behave the same way as SARS-CoV and MERS-CoV, we can use the information gained from both of these earlier coronaviruses to guide us. In general, because of poor survivability of these coronaviruses on surfaces, there is likely very low risk of spread from products or packaging that are shipped over a period of days or weeks at ambient temperatures. Coronaviruses are generally thought to be spread most often by respiratory droplets. Currently there is no evidence to support transmission of COVID-19 associated with imported goods and there have not been any cases of COVID-19 in the United States associated with imported goods. Information will be provided on the Coronavirus Disease 2019 (COVID-19) website as it becomes available."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#ProductsFromChina && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11763",
+      "previous_sibling": "node_11762"
+    },
+    {
+      "type": "standard",
+      "title": "Greeting",
+      "output": {
+        "generic": [
+          {
+            "values": [
+              {
+                "text": "Hello, I’m the COVID Crisis Communication Bot ready to answer your questions about COVID-19. How can I help you?"
+              }
+            ],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          }
+        ]
+      },
+      "conditions": "#greeting",
+      "dialog_node": "node_9_1586187460728",
+      "previous_sibling": "node_11788"
+    },
+    {
+      "type": "standard",
+      "title": "Handwashing tips and Guidance",
+      "output": {
+        "text": {
+          "values": [
+            "Handwashing is one of the best ways to protect yourself and your family from getting sick. Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food. If soap and water are not readily available, use an alcohol-based hand sanitizer with at least 60% alcohol."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#HandwashingTips && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11771",
+      "previous_sibling": "node_11770"
+    },
+    {
+      "type": "standard",
+      "title": "CDC Guidance and Response",
+      "output": {
+        "text": {
+          "values": [
+            "This is an emerging, rapidly evolving situation and CDC will continue to provide updated information as it becomes available. CDC works 24/7 to protect people’s health.  For CDC guidance please visit: https://www.cdc.gov/coronavirus/2019-nCoV/index.html"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#CDC_Response && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11782",
+      "previous_sibling": "node_11781"
+    },
+    {
+      "type": "standard",
+      "title": "Warmer Weather Mitigation",
+      "output": {
+        "text": {
+          "values": [
+            "It is not yet known whether weather and temperature impact the spread of COVID-19. Some other viruses, like the common cold and flu, spread more during cold weather months but that does not mean it is impossible to become sick with these viruses during other months. At this time, it is not known whether the spread of COVID-19 will decrease when weather becomes warmer. There is much more to learn about the transmissibility, severity, and other features associated with COVID-19 and investigations are ongoing."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#warmerweather && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11758",
+      "previous_sibling": "node_11757"
+    },
+    {
+      "type": "standard",
+      "title": "Symptoms of COVID19",
+      "output": {
+        "text": {
+          "values": [
+            "Current symptoms reported for patients with COVID-19 have included mild to severe respiratory illness with fever , cough, and difficulty breathing. Read about COVID-19 Symptoms"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Symptoms && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11776",
+      "previous_sibling": "node_11775"
+    },
+    {
+      "type": "standard",
+      "title": "What is Quarantine",
+      "output": {
+        "text": {
+          "values": [
+            "Quarantine means separating a person or group of people who have been exposed to a contagious disease but have not developed illness (symptoms) from others who have not been exposed, in order to prevent the possible spread of that disease. Quarantine is usually established for the incubation period of the communicable disease, which is the span of time during which people have developed illness after exposure. For COVID-19, the period of quarantine is 14 days from the last date of exposure, because 14 days is the longest incubation period seen for similar coronaviruses. Someone who has been released from COVID-19 quarantine is not considered a risk for spreading the virus to others because they have not developed illness during the incubation period."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#spreadinquarantine && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11756",
+      "previous_sibling": "node_11755"
+    },
+    {
+      "type": "standard",
+      "title": "Testing Information",
+      "output": {
+        "text": {
+          "values": [
+            "If you develop symptoms such as fever, cough, and/or difficulty breathing, and have been in close contact with a person known to have COVID-19 or have recently traveled from an area with ongoing spread of COVID-19 , stay home and call your healthcare provider. Older patients and individuals who have severe underlying medical conditions or are immunocompromised should contact their healthcare provider early, even if their illness is mild. If you have severe symptoms, such as persistent pain or pressure in the chest, new confusion or inability to arouse, or bluish lips of face, contact your healthcare provider or emergency room and seek care immediately. Your doctor will determine if you have signs and symptoms of COVID-19 and whether you should be tested."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Testing && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11777",
+      "previous_sibling": "node_11776"
+    },
+    {
+      "type": "standard",
+      "title": "Disinfecting Surfaces",
+      "output": {
+        "text": {
+          "values": [
+            "Clean and disinfect frequently touched surfaces such as tables, doorknobs, light switches, countertops, handles, desks, phones, keyboards, toilets, faucets, and sinks. If surfaces are dirty, clean them using detergent or soap and water prior to disinfection. To disinfect, most common EPA-registered household disinfectants will work. See CDC’s recommendations for household cleaning and disinfection In Case of an Outbreak in Your Community"
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#DisinfectingSurfaces && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11772",
+      "previous_sibling": "node_11771"
+    },
+    {
+      "type": "standard",
+      "title": "Children and Face Masks",
+      "output": {
+        "text": {
+          "values": [
+            "If your child is healthy, there is no need for them to wear a facemask. Only people who have symptoms of illness or who are providing care to those who are ill should wear masks."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#ChildrenAndFaceMasks && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11767",
+      "previous_sibling": "node_11766"
+    },
+    {
+      "type": "standard",
+      "title": "Person to Person Spread",
+      "output": {
+        "text": {
+          "values": [
+            "The virus that causes COVID-19 is spreading from person-to-person . Someone who is actively sick with COVID-19 can spread the illness to others. That is why CDC recommends that these patients be isolated either in the hospital or at home (depending on how sick they are) until they are better and no longer pose a risk of infecting others. How long someone is actively sick can vary so the decision on when to release someone from isolation is made on a case-by-case basis in consultation with doctors, infection prevention and control experts, and public health officials and involves considering specifics of each situation including disease severity, illness signs and symptoms, and results of laboratory testing for that patient. Current CDC guidance for when it is OK to release someone from isolation is made on a case by case basis and includes meeting all of the following requirements: The patient is free from fever without the use of fever-reducing medications. The patient is no longer showing symptoms, including cough. The patient has tested negative on at least two consecutive respiratory specimens collected at least 24 hours apart. Someone who has been released from isolation is not considered to pose a risk of infection to others."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#PersonToPerson && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11755",
+      "previous_sibling": "node_11754"
+    },
+    {
+      "type": "standard",
+      "title": "Reduce Family Risk",
+      "output": {
+        "text": {
+          "values": [
+            "Practice everyday preventive actions to help reduce your risk of getting sick and remind everyone in your home to do the same. These actions are especially important for older adults and people who have severe chronic medical conditions: Avoid close contact with people who are sick. Cover your coughs and sneezes with a tissue and throw the tissue in the trash. Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food. If soap and water are not readily available, use an alcohol-based hand sanitizer with at least 60% alcohol. Always wash hands with soap and water if hands are visibly dirty. Clean and disinfect frequently touched surfaces and objects (e.g., tables, countertops, light switches, doorknobs, and cabinet handles)."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#ReduceFamilyRisk && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11769",
+      "previous_sibling": "node_11768"
+    },
+    {
+      "type": "standard",
+      "title": "Can I attend funerals?",
+      "output": {
+        "text": {
+          "values": [
+            "There is currently no known risk associated with being in the same room at a funeral or visitation service with the body of someone who died of COVID-19."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#AttendingFuneral && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11781",
+      "previous_sibling": "node_11780"
     },
     {
       "type": "standard",
@@ -2710,18 +2628,47 @@
     },
     {
       "type": "standard",
-      "title": "#Set confidence thresholds",
-      "output": {},
-      "context": {
-        "out_of_bounds": 0.2,
-        "low_confidence": 0.45
+      "title": "Naming of Virus",
+      "output": {
+        "text": {
+          "values": [
+            "On February 11, 2020 the World Health Organization announced an official name for the disease that is causing the 2019 novel coronavirus outbreak, first identified in Wuhan China. The new name of this disease is coronavirus disease 2019, abbreviated as COVID-19. In COVID-19, ‘CO’ stands for ‘corona,’ ‘VI’ for ‘virus,’ and ‘D’ for disease. Formerly, this disease was referred to as “2019 novel coronavirus” or “2019-nCoV”. There are many types of human coronaviruses including some that commonly cause mild upper-respiratory tract illnesses. COVID-19 is a new disease, caused be a novel (or new) coronavirus that has not previously been seen in humans. The name of this disease was selected following the World Health Organization (WHO) best practice for naming of new human infectious diseases."
+          ],
+          "selection_policy": "sequential"
+        },
+        "video": {},
+        "disclaimers": [
+          "SOURCE: https://www.cdc.gov/coronavirus/2019-ncov/faq.html"
+        ]
+      },
+      "context": {},
+      "conditions": "(#Whythename && intents[0].confidence > $low_confidence)",
+      "dialog_node": "node_11752",
+      "previous_sibling": "node_11751"
+    },
+    {
+      "type": "standard",
+      "title": "Welcome",
+      "output": {
+        "generic": [
+          {
+            "values": [],
+            "response_type": "text",
+            "selection_policy": "sequential"
+          }
+        ]
+      },
+      "metadata": {
+        "_customization": {
+          "mcr": false
+        }
       },
       "next_step": {
         "behavior": "jump_to",
-        "selector": "condition",
-        "dialog_node": "node_11789"
+        "selector": "body",
+        "dialog_node": "node_9_1586187460728"
       },
-      "conditions": "conversation_start",
+      "conditions": "welcome",
       "dialog_node": "node_11788"
     }
   ],


### PR DESCRIPTION
Replaced conversation start with welcome node and removed threshold references
1. the converstion_start node and the login in the children node were talking an issue when sessions timed out in the preview link and web applications.

I replaced the "conversation_start" node with welcome node. This is also easier to read as a new user. Also removed all references to the `threshold` in all nodes in the dialog.

Tested the `Try it panel` and the `preview link`.