### PR TITLE
Bug in action - because of the change of the json format api.covid19api.com

### DIFF
--- a/starter-kit/webhook/action/covid-webhook.js
+++ b/starter-kit/webhook/action/covid-webhook.js
@@ -31,7 +31,7 @@ async function main(params) {
       if (params.country) {
         for (var i = 0; i < summary.Countries.length; i++) {
           if (
-            summary.Countries[i].Country.toLowerCase() ===
+            summary.Countries[i].CountryCode.toLowerCase() ===
             params.country.toLowerCase()
           ) {
             return {


### PR DESCRIPTION
Today I did a test of the Assistant and I notice we  need to use **"CountryCode"** and not **"Country"**

 new: **summary.Countries[i].CountryCode.toLowerCase()**
 old:  _summary.Countries[i].Country.toLowerCase()_

New JSON format : https://api.covid19api.com/summary and search for US
```json
{
"Country": "United States of America",
"CountryCode": "US",
"Slug": "united-states",
"NewConfirmed": 25231,
"TotalConfirmed": 783710,
"NewDeaths": 1431,
"TotalDeaths": 42075,
"NewRecovered": 1992,
"TotalRecovered": 72329,
"Date": "2020-04-21T08:44:36Z"
}
```
Change in code needed: use **"CountryCode"** and not **"Country"**

**right value**: Countries[i].CountryCode == "US"
**wrong value**: Countries[i].Country == "United States of America"

```
...
          if (
            summary.Countries[i].CountryCode.toLowerCase() ===
            params.country.toLowerCase()
          ) 
...
```